### PR TITLE
fix Instance class not found on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Browse, edit and compile your source members right from Visual Studio Code.
 * [@worksofliam](https://github.com/worksofliam)
 * [@alanseiden](https://github.com/alanseiden)
 * [@richardschoen](https://github.com/richardschoen)
+* [@barrettotte](https://github.com/barrettotte)
 
 ## Guide
 

--- a/extension.js
+++ b/extension.js
@@ -5,7 +5,7 @@ const vscode = require('vscode');
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 
-var instance = require('./src/instance');
+var instance = require('./src/Instance');
 const LoginPanel = require('./src/webviews/login');
 
 /**

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -5,7 +5,7 @@ const IBMi = require('./api/IBMi');
 const IBMiContent = require("./api/IBMiContent");
 const CompileTools = require("./api/CompileTools");
 
-module.exports = class {
+module.exports = class Instance {
   static setConnection(conn) {
     instance.connection = conn;
     instance.content = new IBMiContent(instance.connection);

--- a/src/views/memberBrowser.js
+++ b/src/views/memberBrowser.js
@@ -1,7 +1,7 @@
 
 const vscode = require('vscode');
 
-var instance = require('../instance');
+var instance = require('../Instance');
 
 module.exports = class memberBrowserProvider {
   /**

--- a/src/views/qsysFs.js
+++ b/src/views/qsysFs.js
@@ -1,7 +1,7 @@
 
 const util = require('util');
 const vscode = require('vscode');
-var instance = require('../instance');
+var instance = require('../Instance');
 
 module.exports = class qsysFs {
   constructor() {

--- a/src/webviews/login/index.js
+++ b/src/webviews/login/index.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 
 const IBMi = require('../../api/IBMi');
 
-var instance = require('../../instance');
+var instance = require('../../Instance');
 
 const LoginHTML = fs.readFileSync(path.join(__dirname, 'login.html'), {encoding: 'utf8'});
 


### PR DESCRIPTION
This was quite a weird one because I didn't encounter any issues on Windows at all. Perhaps it's Windows or different versions of Node that makes file naming a little more relaxed, I'm still a bit confused. 

I encountered the same error as https://github.com/halcyon-tech/code-for-ibmi/issues/14 on Ubuntu 20.04.2 and VS Code 1.53.2.

```
Activating extension 'halcyontechltd.code-for-ibmi' failed: Cannot find module './src/instance'
Require stack:
- /home/barrett/Programming/code-for-ibmi/extension.js
- /usr/share/code/resources/app/out/vs/loader.js
- /usr/share/code/resources/app/out/bootstrap-amd.js
- /usr/share/code/resources/app/out/bootstrap-fork.js.
```

I debugged it locally and found that multiple files had a problem resolving the paths to 'Instance.js'
So, I changed the import paths from 'instance' to 'Instance'.
I also added the explicit class name Instance to 'Instance.js' although I don't think its completely necessary.

This appears to have fixed the problem on Ubuntu and I am able to get the connection prompt to appear.
However, I can only get as far as attempting the connection.
I guess I locked myself out of my PUB400 account so I cannot check further than this on Linux.

I also checked on Windows and this fix does not seem to break anything and works as it did before.