### PR TITLE
Start of object browser (#26)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,7 @@ The two available `type` property values are:
 
 * `member` for source members
 * `streamfile` for streamfiles
+* `object` for objects
 
 You can also use the `environment` property to run the action in a certain environment:
 
@@ -98,6 +99,14 @@ Notice the special identifiers in the command begining with `&`. These identifie
 | &FULLPATH | Path to the streamfile.                         |
 | &NAME     | Name of the streamfile with no extension        |
 | &EXT      | Extension of basename                           |
+
+#### Object variables
+
+| Variable  | Usage                             |
+|-----------|-----------------------------------|
+| &LIBRARY  | Library which the object exists   |
+| &NAME     | Name of the object                |
+| &TYPE     | The object type (PGM, FILE, etc)  |
 
 New actions can be added by defining a new action object in the settings like the snippet listed above.
 

--- a/package.json
+++ b/package.json
@@ -560,7 +560,7 @@
 				},
 				{
 					"command": "code-for-ibmi.refreshObjectList",
-					"when": "view == memberBrowser && viewItem == library"
+					"when": "view == objectBrowser && viewItem == library"
 				},
 				{
 					"command": "code-for-ibmi.runActionFromView",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
 		"onCommand:code-for-ibmi.createDirectory",
 		"onCommand:code-for-ibmi.createStreamfile",
 		"onCommand:code-for-ibmi.moveIFS",
-		"onCommand:code-for-ibmi.deleteIFS"
+		"onCommand:code-for-ibmi.deleteIFS",
+		"onView:objectBrowser",
+		"onCommand:code-for-ibmi.refreshObjectList"
 	],
 	"main": "./extension.js",
 	"contributes": {
@@ -392,6 +394,12 @@
 				"title": "Create streamfile",
 				"category": "IBM i",
 				"icon": "$(new-file)"
+			},
+			{
+				"command": "code-for-ibmi.refreshObjectList",
+				"title": "Refresh Object List",
+				"category": "IBM i",
+				"icon": "$(refresh)"
 			}
 		],
 		"keybindings": [
@@ -423,6 +431,11 @@
 					"name": "IFS Browser",
 					"contextualTitle": "IFS Browser",
 					"icon": "media/server.svg"
+				},
+				{
+					"id": "objectBrowser",
+					"name": "Object Browser",
+					"contextualTitle": "Object Browser"
 				}
 			]
 		},
@@ -457,6 +470,11 @@
 					"command": "code-for-ibmi.refreshIFSBrowser",
 					"group": "navigation",
 					"when": "view == ifsBrowser"
+				},
+				{
+					"command": "code-for-ibmi.refreshObjectList",
+					"group": "navigation",
+					"when": "view == objectBrowser"
 				}
 			],
 			"view/item/context": [
@@ -523,6 +541,10 @@
 					"command": "code-for-ibmi.createStreamfile",
 					"when": "view == ifsBrowser && viewItem == directory",
 					"group": "2_ifsStuff@1"
+				},
+				{
+					"command": "code-for-ibmi.refreshObjectList",
+					"when": "view == memberBrowser && viewItem == library"
 				}
 			]
 		},

--- a/package.json
+++ b/package.json
@@ -276,6 +276,22 @@
 							],
 							"name": "Create Program (CRTPGM)",
 							"command": "?CRTPGM PGM(&OPENLIB/&OPENMBR) MODULE(*PGM) ENTMOD(*FIRST) BNDSRVPGM(*NONE) BNDDIR(*NONE) ACTGRP(*ENTMOD) TGTRLS(*CURRENT)"
+						},
+						{
+							"type": "object",
+							"extensions": [
+								"GLOBAL"
+							],
+							"name": "Delete object",
+							"command": "DLTOBJ OBJ(&LIBRARY/&NAME) OBJTYPE(*&TYPE)"
+						},
+						{
+							"type": "object",
+							"extensions": [
+								"pgm"
+							],
+							"name": "Call program",
+							"command": "CALL &LIBRARY/&NAME"
 						}
 					]
 				}
@@ -545,6 +561,11 @@
 				{
 					"command": "code-for-ibmi.refreshObjectList",
 					"when": "view == memberBrowser && viewItem == library"
+				},
+				{
+					"command": "code-for-ibmi.runActionFromView",
+					"when": "view == objectBrowser && viewItem == object",
+					"group": "1_workspace@1"
 				}
 			]
 		},

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -72,6 +72,8 @@ module.exports = class Instance {
     const ifsBrowser = require('./views/ifsBrowser');
     const ifs = new (require('./views/ifs'));
 
+    const objectBrowser = require('./views/objectBrowser');
+
     if (instance.connection) {
       CompileTools.register(context);
 
@@ -133,6 +135,14 @@ module.exports = class Instance {
             isCaseSensitive: false
           })
         );
+
+        //********* Object Browser */
+        
+        context.subscriptions.push(
+          vscode.window.registerTreeDataProvider(
+            'objectBrowser',
+            new objectBrowser(context)
+        ));
 
         //********* General editing */
   

--- a/src/api/CompileTools.js
+++ b/src/api/CompileTools.js
@@ -228,6 +228,7 @@ module.exports = class CompileTools {
             if (commandResult.code === 0 || commandResult.code === null) {
               executed = true;
               vscode.window.showInformationMessage(`Action ${chosenOptionName} for ${evfeventInfo.lib}/${evfeventInfo.object} was successful.`);
+              if (connection.autoRefresh) vscode.commands.executeCommand(`code-for-ibmi.refreshObjectList`, evfeventInfo.lib);
               
             } else {
               executed = false;

--- a/src/api/CompileTools.js
+++ b/src/api/CompileTools.js
@@ -128,11 +128,12 @@ module.exports = class CompileTools {
         command = availableActions.find(action => action.name === chosenOptionName).command;
         environment = availableActions.find(action => action.name === chosenOptionName).environment || 'ile';
 
+        let blank, lib, file, fullName;
         let basename, name, ext;
 
         switch (uri.scheme) {
           case 'member':
-            const [blank, lib, file, fullName] = uri.path.split('/');
+            [blank, lib, file, fullName] = uri.path.split('/');
             name = fullName.substring(0, fullName.lastIndexOf('.'));
 
             ext = (fullName.includes('.') ? fullName.substring(fullName.lastIndexOf('.') + 1) : undefined);
@@ -166,6 +167,21 @@ module.exports = class CompileTools {
             command = command.replace(new RegExp('&NAME', 'g'), name);
             command = command.replace(new RegExp('&EXT', 'g'), ext);
 
+            break;
+
+          case 'object':
+            [blank, lib, fullName] = uri.path.split('/');
+            name = fullName.substring(0, fullName.lastIndexOf('.'));
+
+            evfeventInfo = {
+              lib,
+              object: name,
+              extension
+            };
+
+            command = command.replace(new RegExp('&LIBRARY', 'g'), lib);
+            command = command.replace(new RegExp('&NAME', 'g'), name);
+            command = command.replace(new RegExp('&TYPE', 'g'), extension);
             break;
         }
 

--- a/src/api/IBMiContent.js
+++ b/src/api/IBMiContent.js
@@ -153,6 +153,34 @@ module.exports = class IBMiContent {
 
   /**
    * @param {string} lib 
+   * @returns {Promise<{library: string, name: string, type: string, text: string}[]>} List of members 
+   */
+  async getObjectList(lib) {
+    lib = lib.toUpperCase();
+
+    const tempLib = this.ibmi.tempLibrary;
+    const TempName = IBMi.makeid();
+
+    await this.ibmi.remoteCommand(`DSPOBJD OBJ(${lib}/*ALL) OBJTYPE(*ALL) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${TempName})`);
+    const results = await this.getTable(tempLib, TempName, TempName);
+
+    if (results.length === 1) {
+      if (results[0].MBNAME.trim() === '') {
+        return []
+      }
+    }
+
+    return results.map(object => ({
+      library: lib,
+      name: object.ODOBNM,
+      type: object.ODOBTP,
+      attribute: object.ODOBAT,
+      text: object.ODOBTX
+    }))
+  }
+
+  /**
+   * @param {string} lib 
    * @param {string} spf
    * @returns {Promise<{library: string, file: string, name: string, extension: string, recordLength: number, text: string}[]>} List of members 
    */

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -124,7 +124,7 @@ class Object extends vscode.TreeItem {
    */
   constructor({library, name, type, text}) {
     if (type.startsWith('*')) type = type.substring(1);
-    
+
     const icon = objectIcons[type] || objectIcons[''];
 
     super(`${name.toLowerCase()}.${type.toLowerCase()}`);
@@ -133,7 +133,8 @@ class Object extends vscode.TreeItem {
     this.path = `${library}/${name}`;
     this.type = type;
     this.description = text;
-    this.iconPath = new vscode.ThemeIcon(icon)
+    this.iconPath = new vscode.ThemeIcon(icon);
+    this.resourceUri = vscode.Uri.parse(`${library}/${name}.${type}`).with({scheme: 'object'})
   }
 }
 

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -141,6 +141,8 @@ class Object extends vscode.TreeItem {
 //https://code.visualstudio.com/api/references/icons-in-labels
 const objectIcons = {
   'FILE': 'database',
-  'PGM': 'terminal', 
+  'CMD': 'terminal',
+  'MODULE': 'extensions',
+  'PGM': 'chevron-right',
   '': 'circle-large-outline'
 }

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -26,8 +26,16 @@ module.exports = class objectBrowserProvider {
         }
       }),
 
-      vscode.commands.registerCommand(`code-for-ibmi.refreshObjectList`, async () => {
-        this.refresh();
+      vscode.commands.registerCommand(`code-for-ibmi.refreshObjectList`, async (library) => {
+        if (library) {
+          if (typeof library === "string") {
+            this.refresh(library);
+          } else if (library.path) {
+            this.refresh(library.path);
+          }
+        } else {
+          this.refresh();
+        }
       })
     )
   }

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -143,6 +143,6 @@ const objectIcons = {
   'FILE': 'database',
   'CMD': 'terminal',
   'MODULE': 'extensions',
-  'PGM': 'chevron-right',
+  'PGM': 'file-binary',
   '': 'circle-large-outline'
 }

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -1,0 +1,145 @@
+
+const vscode = require('vscode');
+
+var instance = require('../Instance');
+
+module.exports = class objectBrowserProvider {
+  /**
+   * @param {vscode.ExtensionContext} context
+   */
+  constructor(context) {
+    this.selections = undefined;
+    this.emitter = new vscode.EventEmitter();
+    this.onDidChangeTreeData = this.emitter.event;
+
+    // used for targeted member list refreshes
+    this.targetLib = '*ALL';
+
+    /** @type {{[library: string]: Object[]}} */
+    this.refreshCache = {};
+
+    context.subscriptions.push(
+      vscode.workspace.onDidChangeConfiguration(event => {
+        let affected = event.affectsConfiguration("code-for-ibmi.libraryList");
+        if (affected) {
+          this.refresh();
+        }
+      }),
+
+      vscode.commands.registerCommand(`code-for-ibmi.refreshObjectList`, async () => {
+        this.refresh();
+      })
+    )
+  }
+
+  /**
+   * @param {string} lib 
+   */
+  refresh(lib = '*ALL') {
+    this.targetLib = lib;
+    this.emitter.fire();
+  }
+
+  /**
+   * @param {vscode.TreeItem} element
+   * @returns {vscode.TreeItem};
+   */
+  getTreeItem(element) {
+    return element;
+  }
+
+  /**
+   * @param {Library?} element
+   * @returns {Promise<vscode.TreeItem[]>};
+   */
+  async getChildren(element) {
+    const content = instance.getContent();
+    var items = [], item;
+
+    if (element) { //Chosen SPF
+      //Fetch members
+      console.log(element.path);
+      const lib = element.path;
+
+      // init cache entry if not exists
+      var cacheExists = element.path in this.refreshCache;
+      if (!cacheExists) {
+        this.refreshCache[element.path] = []; // init cache entry
+      }
+
+      // only refresh member list for specific target, all LIB/SPF, or if cache entry didn't exist
+      if (!cacheExists || ([lib, '*ALL'].includes(this.targetLib))) {
+        try {
+          const objects = await content.getObjectList(lib);
+          this.refreshCache[element.path] = []; // reset cache since we're getting new data
+
+          let listItem;
+          for (const object of objects) {
+            listItem = new Object(object);
+            items.push(listItem);
+            this.refreshCache[element.path].push(listItem);
+          }
+        } catch (e) {
+          console.log(e);
+          item = new vscode.TreeItem("Error loading members.");
+          vscode.window.showErrorMessage(e);
+          items = [item];
+        }
+
+      } else {
+        // add cached items to tree
+        items.push(...this.refreshCache[element.path]);
+      }
+    } else {
+      const connection = instance.getConnection();
+      if (connection) {
+        const libraries = connection.libraryList;
+
+        for (var library of libraries) {
+          library = library.toUpperCase();
+          items.push(new Library(library));
+        }
+      }
+    }
+    return items;
+  }
+}
+
+class Library extends vscode.TreeItem {
+  /**
+   * @param {string} label
+   */
+  constructor(label) {
+    super(label, vscode.TreeItemCollapsibleState.Collapsed);
+
+    this.contextValue = 'library';
+    this.path = label.toUpperCase();
+  }
+}
+
+class Object extends vscode.TreeItem {
+  /**
+   * 
+   * @param {{library: string, name: string, type: string, text: string}} objectInfo
+   */
+  constructor({library, name, type, text}) {
+    if (type.startsWith('*')) type = type.substring(1);
+    
+    const icon = objectIcons[type] || objectIcons[''];
+
+    super(`${name.toLowerCase()}.${type.toLowerCase()}`);
+
+    this.contextValue = 'object';
+    this.path = `${library}/${name}`;
+    this.type = type;
+    this.description = text;
+    this.iconPath = new vscode.ThemeIcon(icon)
+  }
+}
+
+//https://code.visualstudio.com/api/references/icons-in-labels
+const objectIcons = {
+  'FILE': 'database',
+  'PGM': 'terminal', 
+  '': 'circle-large-outline'
+}


### PR DESCRIPTION
### Changes

Covers issue #26. This adds an object browser to the IBM i view. I am using the same caching technique used in the member browser by @barrettotte.

Right-click contexts include:

* Run Action

### Checklist

* [X] have tested my change
* [x] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [X] have added myself to the contributors' list in the README
