### PR TITLE
Feature/database browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
 		"onCommand:code-for-ibmi.moveIFS",
 		"onCommand:code-for-ibmi.deleteIFS",
 		"onView:objectBrowser",
-		"onCommand:code-for-ibmi.refreshObjectList"
+		"onCommand:code-for-ibmi.refreshObjectList",
+		"onView:databaseBrowser",
+		"onCommand:code-for-ibmi.refreshDatabaseBrowser"
 	],
 	"main": "./extension.js",
 	"contributes": {
@@ -416,6 +418,12 @@
 				"title": "Refresh Object List",
 				"category": "IBM i",
 				"icon": "$(refresh)"
+			},
+			{
+				"command": "code-for-ibmi.refreshDatabaseBrowser",
+				"title": "Refresh Object List",
+				"category": "IBM i",
+				"icon": "$(refresh)"
 			}
 		],
 		"keybindings": [
@@ -452,6 +460,11 @@
 					"id": "objectBrowser",
 					"name": "Object Browser",
 					"contextualTitle": "Object Browser"
+				},
+				{
+					"id": "databaseBrowser",
+					"name": "Database Browser",
+					"contextualTitle": "Database Browser"
 				}
 			]
 		},
@@ -491,6 +504,11 @@
 					"command": "code-for-ibmi.refreshObjectList",
 					"group": "navigation",
 					"when": "view == objectBrowser"
+				},
+				{
+					"command": "code-for-ibmi.refreshDatabaseBrowser",
+					"group": "navigation",
+					"when": "view == databaseBrowser"
 				}
 			],
 			"view/item/context": [

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -73,6 +73,7 @@ module.exports = class Instance {
     const ifs = new (require('./views/ifs'));
 
     const objectBrowser = require('./views/objectBrowser');
+    const databaseBrowser = require('./views/databaseBrowser');
 
     if (instance.connection) {
       CompileTools.register(context);
@@ -142,6 +143,12 @@ module.exports = class Instance {
           vscode.window.registerTreeDataProvider(
             'objectBrowser',
             new objectBrowser(context)
+        ));
+        
+        context.subscriptions.push(
+          vscode.window.registerTreeDataProvider(
+            'databaseBrowser',
+            new databaseBrowser(context)
         ));
 
         //********* General editing */

--- a/src/api/IBMi.js
+++ b/src/api/IBMi.js
@@ -9,6 +9,12 @@ module.exports = class IBMi {
     this.currentUser = '';
     this.tempRemoteFiles = {};
     this.defaultUserLibraries = [];
+
+    /** @type {{[name: string]: string}} */
+    this.remoteFeatures = {
+      db2util: undefined,
+      git: undefined
+    };
     
     //Configration:
     this.homeDirectory = '.';
@@ -114,6 +120,20 @@ module.exports = class IBMi {
 
         console.log(e);
       }
+
+      //Next, we see what pase features are available (installed via yum)
+      const packagesPath = `/QOpenSys/pkgs/bin/`;
+      try {
+        //This may enable certain features in the future.
+        const call = await this.paseCommand(`ls -p ${packagesPath}`);
+        if (typeof call === "string") {
+          const files = call.split('\n');
+          for (const feature of Object.keys(this.remoteFeatures))
+            if (files.includes(feature))
+              this.remoteFeatures[feature] = packagesPath + feature;
+        }
+        
+      } catch (e) {}
 
       return true;
 

--- a/src/api/IBMiContent.js
+++ b/src/api/IBMiContent.js
@@ -117,6 +117,38 @@ module.exports = class IBMiContent {
       return Promise.reject(error);
     }
   }
+  
+  /**
+   * Run an SQL statement
+   * @param {string} statement 
+   * @returns {Promise<any[]>} Result set
+   */
+  async runSQL(statement) {
+    const command = this.ibmi.remoteFeatures.db2util;
+
+    if (command) {
+      statement = statement.replace(/"/g, '\\"');
+      try {
+        let output = await this.ibmi.paseCommand(`DB2UTIL_JSON_CONTAINER=array ${command} -o json "${statement}"`);
+
+        if (typeof output === "string") {
+          const rows = JSON.parse(output);
+          for (var row of rows)
+            for (var key in row)
+              if (typeof row[key] === 'string') row[key] = row[key].trim();
+
+          return rows;
+        } else {
+          return [];
+        }
+
+      } catch (e) {
+        return [];
+      }
+    } else {
+      throw new Error("db2util not installed on remote server.");
+    }
+  }
 
   /**
    * Download the contents of a table.

--- a/src/views/databaseBrowser.js
+++ b/src/views/databaseBrowser.js
@@ -54,7 +54,7 @@ module.exports = class databaseBrowserProvider {
       } else 
       
       if (element instanceof TableItem) {
-        console.log(element.table.columns);
+        items.push(...element.table.columns.map(column => new ColumnItem(column)));
       }
 
     } else {
@@ -83,6 +83,7 @@ class SchemaItem extends vscode.TreeItem {
 
     this.contextValue = 'schema';
     this.path = name;
+    this.iconPath = new vscode.ThemeIcon('database');
   }
 }
 
@@ -91,10 +92,44 @@ class TableItem extends vscode.TreeItem {
    * @param {Table} table 
    */
   constructor(table) {
-    super(table.name.toLowerCase(), vscode.TreeItemCollapsibleState.Collapsed);
+    super(table.name.toLowerCase());
+
+    this.contextValue = 'table';
+    this.tooltip = table.type;
+    this.iconPath = new vscode.ThemeIcon(TABLE_ICONS[table._type]);
+
+    if (table._type === 'A') {
+      this.collapsibleState = vscode.TreeItemCollapsibleState.None;
+      this.description = `${table.type} - ${table.base}. ${table.text}`;
+    } else {
+      this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+      this.description = `${table.type}. ${table.text}`;
+    }
 
     /** @type {Table} */
     this.table = table;
-    this.description = table.text;
   }
+}
+
+class ColumnItem extends vscode.TreeItem {
+  /**
+   * 
+   * @param {Column} column 
+   */
+  constructor(column) {
+    super(column.name.toLowerCase(), vscode.TreeItemCollapsibleState.None);
+
+    this.description = `${column.type.toLowerCase()}. ${column.heading}`;
+    this.tooltip = column.comment;
+    this.iconPath = new vscode.ThemeIcon('circle-filled');
+  }
+}
+
+const TABLE_ICONS = {
+  'A': 'files',
+  'L': 'filter',
+  'M': 'file-symlink-file',
+  'P': 'list-flat',
+  'T': 'list-flat',
+  'V': 'eye'
 }

--- a/src/views/databaseBrowser.js
+++ b/src/views/databaseBrowser.js
@@ -1,0 +1,63 @@
+
+const vscode = require('vscode');
+
+var instance = require('../Instance');
+
+module.exports = class databaseBrowserProvider {
+  /**
+   * @param {vscode.ExtensionContext} context
+   */
+  constructor(context) {
+    this.emitter = new vscode.EventEmitter();
+    this.onDidChangeTreeData = this.emitter.event;
+
+    context.subscriptions.push(
+      vscode.workspace.onDidChangeConfiguration(event => {
+        let affected = event.affectsConfiguration("code-for-ibmi.libraryList");
+        if (affected) {
+          this.refresh();
+        }
+      }),
+
+      vscode.commands.registerCommand(`code-for-ibmi.refreshDatabaseBrowser`, async () => {
+        this.refresh();
+      })
+    )
+  }
+
+  refresh() {
+    this.emitter.fire();
+  }
+
+  /**
+   * @param {vscode.TreeItem} element
+   * @returns {vscode.TreeItem};
+   */
+  getTreeItem(element) {
+    return element;
+  }
+
+  /**
+   * @param {vscode.TreeItem?} element
+   * @returns {Promise<vscode.TreeItem[]>};
+   */
+  async getChildren(element) {
+    const content = instance.getContent();
+    var items = [], item;
+
+    if (element) { 
+      
+    } else {
+      const connection = instance.getConnection();
+      if (connection) {
+        const libraries = connection.libraryList;
+
+        for (var library of libraries) {
+          library = library.toUpperCase();
+          items.push(new SPF(shortcut, shortcut));
+        }
+      }
+    }
+    return items;
+  }
+}

--- a/src/views/databaseBrowser.js
+++ b/src/views/databaseBrowser.js
@@ -79,7 +79,7 @@ module.exports = class databaseBrowserProvider {
 
 class SchemaItem extends vscode.TreeItem {
   constructor(name) {
-    super(name.toLowerCase());
+    super(name.toLowerCase(), vscode.TreeItemCollapsibleState.Collapsed);
 
     this.contextValue = 'schema';
     this.path = name;

--- a/src/views/databaseFs.js
+++ b/src/views/databaseFs.js
@@ -14,7 +14,7 @@ class Database {
     schema = schema.toUpperCase();
 
     const [tablesResult, columnsResult] = await Promise.all([
-      content.runSQL(`select TABLE_NAME, TABLE_TYPE, TABLE_TEXT from QSYS2.SYSTABLES where TABLE_SCHEMA = '${schema}'`),
+      content.runSQL(`select TABLE_NAME, TABLE_TYPE, TABLE_TEXT, BASE_TABLE_SCHEMA, BASE_TABLE_NAME from QSYS2.SYSTABLES where TABLE_SCHEMA = '${schema}'`),
       content.runSQL(`select * from QSYS2.SYSCOLUMNS where TABLE_SCHEMA = '${schema}' order by ORDINAL_POSITION asc`)
     ]);
 
@@ -48,6 +48,12 @@ class Table {
     this._type = row.TABLE_TYPE;
     this.type = TABLE_TYPES[row.TABLE_TYPE];
     this.text = row.TABLE_TEXT;
+
+    if (this._type === 'A') {
+      //Is ALIAS
+
+      this.base = `${row.BASE_TABLE_SCHEMA}/${row.BASE_TABLE_NAME}`;
+    }
 
     /** @type {Column[]} */
     this.columns = [];    

--- a/src/views/databaseFs.js
+++ b/src/views/databaseFs.js
@@ -11,6 +11,8 @@ class Database {
   static async getObjects(schema) {
     const content = instance.getContent();
 
+    schema = schema.toUpperCase();
+
     const [tablesResult, columnsResult] = await Promise.all([
       content.runSQL(`select TABLE_NAME, TABLE_TYPE, TABLE_TEXT from QSYS2.SYSTABLES where TABLE_SCHEMA = '${schema}'`),
       content.runSQL(`select * from QSYS2.SYSCOLUMNS where TABLE_SCHEMA = '${schema}' order by ORDINAL_POSITION asc`)

--- a/src/views/databaseFs.js
+++ b/src/views/databaseFs.js
@@ -1,0 +1,75 @@
+
+
+var instance = require('../Instance');
+
+class Database {
+
+  /**
+   * @param {string} schema 
+   * @returns {Promise<Table[]>}
+   */
+  static async getObjects(schema) {
+    const content = instance.getContent();
+
+    const [tablesResult, columnsResult] = await Promise.all([
+      content.runSQL(`select TABLE_NAME, TABLE_TYPE, TABLE_TEXT from QSYS2.SYSTABLES where TABLE_SCHEMA = '${schema}'`),
+      content.runSQL(`select * from QSYS2.SYSCOLUMNS where TABLE_SCHEMA = '${schema}' order by ORDINAL_POSITION asc`)
+    ]);
+
+    /** @type {Table[]} */
+    let tables = [];
+
+    tables = tablesResult.map(row => new Table(row));
+
+    let currentColumns;
+    for (const table of tables) {
+      currentColumns = columnsResult.filter(row => row.TABLE_NAME === table.name);
+      table.columns.push(...currentColumns.map(column => new Column(column)));
+    }
+
+    return tables;
+  }
+}
+
+const TABLE_TYPES = {
+  A: 'Alias',
+  L: 'Logical file',
+  M: 'Materialized query table',
+  P: 'Physical file',
+  T: 'Table',
+  V: 'View'
+}
+
+class Table {
+  constructor(row) {
+    this.name = row.TABLE_NAME;
+    this._type = row.TABLE_TYPE;
+    this.type = TABLE_TYPES[row.TABLE_TYPE];
+    this.text = row.TABLE_TEXT;
+
+    /** @type {Column[]} */
+    this.columns = [];    
+  }
+}
+
+class Column {
+  constructor(row) {
+    this.name = row.COLUMN_NAME;
+    this.table = row.TABLE_NAME;
+    this.schema = row.TABLE_SCHEMA;
+
+    this.type = row.DATA_TYPE;
+    this.length = row.LENGTH;
+    this.scale = row.NUMERIC_SCALE;
+    this.precision = row.NUMERIC_PRECISION;
+
+    this.nullable = row.IS_NULLABLE;
+    this.default = row.COLUMN_DEFAULT;
+    this.identity = (row.IS_IDENTITY === 'YES');
+
+    this.heading = row.COLUMN_HEADING;
+    this.comment = row.LONG_COMMENT;
+  }
+}
+
+module.exports = {Database, TABLE_TYPES, Table, Column};


### PR DESCRIPTION
### Changes

This adds a new view to the IBM i panel which is a database browser. It allows the user to view table objects (tables, PFs, LFs, views, aliases) inside of a schema (based on the library list).

It also lets you see the columns of that database object.

To do:

* [ ] Context menu for objects to run statements over them. E.g. Right-click -> Generate SELECT (or something?)
* [ ] A window that lets you run SQL statements and also saves previous statements so you can execute them again.
* [ ] Anything else

Screenshot:

![image](https://user-images.githubusercontent.com/3708366/109440421-3902b700-7a00-11eb-84ea-052f8d87ba75.png)

### Checklist

* [ ] have tested my change
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
