### PR TITLE
Feature/seperate configs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -111,8 +111,11 @@ Notice the special identifiers in the command begining with `&`. These identifie
 New actions can be added by defining a new action object in the settings like the snippet listed above.
 
 ### Auto Refresh
-When enabled, listings will refresh when items are interacted with (create, copy, delete, etc). If performance is bad, it is suggested to disable this option.
+When enabled, listings will refresh when items are interacted with (create, copy, delete, etc). If performance is bad, it is suggested you disable this option.
 
+### Log Compile Output
+When enabled, spool files will be logged from command execution.
+These spool files can be found under **OUTPUT** / **IBM i Compile Log**.
 ### Connections
 List of connection details from prior connections.
 
@@ -130,7 +133,29 @@ Here is a snippet of what the connection details look like:
 
 #### Connection Settings
 
-Each connection gets some of their own properties. **Note that connection properties can only be edited in the form of JSON, other than certain places in the UI**
+An array of objects. Each object is unique by the host property and is used so different connections can have their own settings. **Note that connection properties can only be edited in the form of JSON, other than certain places in the UI**
+
+```json
+    "code-for-ibmi.connectionSettings": [
+        {
+            "host": "seiden.iinthecloud.com",
+            "sourceFileList": [
+                "QSYSINC/H",
+                "BARRY/QRPGLESRC",
+                "MYPROJ/QRPGLESRC"
+            ],
+            "libraryList": [
+                "QSYS2",
+                "QSYSINC",
+                "SAMPLE"
+            ],
+            "homeDirectory": "/home/alan3/apug",
+            "temporaryLibrary": "ILEDITOR",
+            "buildLibrary": "QTEMP",
+            "sourceASP": null
+        }
+    ]
+```
 
 #### Source File List
 Source files to be included in the member browser.
@@ -150,14 +175,6 @@ A library that can be defined/changes for IFS builds.
 #### Source ASP
 If source files are located in a specific ASP, specify here. 
 Otherwise, leave blank.
-
-
-### Temporary Library
-Temporary library used by extension. This cannot be QTEMP.
-
-### Log Compile Output
-When enabled, spool files will be logged from command execution.
-These spool files can be found under **OUTPUT** / **IBM i Compile Log**.
 
 ## Adding Source Files
 In order to make the member browser useful, source files need to be declared

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,26 +128,36 @@ Here is a snippet of what the connection details look like:
 ],
 ```
 
-### Home Directory
+#### Connection Settings
+
+Each connection gets some of their own properties. **Note that connection properties can only be edited in the form of JSON, other than certain places in the UI**
+
+#### Source File List
+Source files to be included in the member browser.
+
+#### Library List
+An array for the library list. Highest item of the library list goes first.
+
+#### Home Directory
 Home directory for user. This directory is also the root for the IFS browser.
 
-### Library List
-Comma delimited list for library list.
+#### Temporary library
+Temporary library. Is used OUTPUT files. Cannot be QTEMP.
 
-### Log Compile Output
-When enabled, spool files will be logged from command execution.
-These spool files can be found under **OUTPUT** / **IBM i Compile Log**.
+#### Build library
+A library that can be defined/changes for IFS builds.
 
-### Source ASP
+#### Source ASP
 If source files are located in a specific ASP, specify here. 
 Otherwise, leave blank.
 
-### Source File List
-Source files to be included in the member browser.
 
 ### Temporary Library
 Temporary library used by extension. This cannot be QTEMP.
 
+### Log Compile Output
+When enabled, spool files will be logged from command execution.
+These spool files can be found under **OUTPUT** / **IBM i Compile Log**.
 
 ## Adding Source Files
 In order to make the member browser useful, source files need to be declared

--- a/extension.js
+++ b/extension.js
@@ -13,41 +13,41 @@ const LoginPanel = require(`./src/webviews/login`);
  */
 function activate(context) {
 
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log(`Congratulations, your extension "code-for-ibmi" is now active!`);
+  // Use the console to output diagnostic information (console.log) and errors (console.error)
+  // This line of code will only be executed once when your extension is activated
+  console.log(`Congratulations, your extension "code-for-ibmi" is now active!`);
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with  registerCommand
-	// The commandId parameter must match the command field in package.json
-	context.subscriptions.push(
-		vscode.commands.registerCommand(`code-for-ibmi.connect`, function () {
-			LoginPanel.show(context);
-		})
-	);
+  // The command has been defined in the package.json file
+  // Now provide the implementation of the command with  registerCommand
+  // The commandId parameter must match the command field in package.json
+  context.subscriptions.push(
+    vscode.commands.registerCommand(`code-for-ibmi.connect`, function () {
+      LoginPanel.show(context);
+    })
+  );
 
-	context.subscriptions.push(
-		vscode.commands.registerCommand(`code-for-ibmi.connectPrevious`, function () {
-			LoginPanel.LoginToPrevious(context);
-		})
-	);
+  context.subscriptions.push(
+    vscode.commands.registerCommand(`code-for-ibmi.connectPrevious`, function () {
+      LoginPanel.LoginToPrevious(context);
+    })
+  );
 
-	context.subscriptions.push(
-		vscode.workspace.onDidChangeConfiguration(event => {
-			const connection = instance.getConnection();
-			if (connection) {
-				if (event.affectsConfiguration(`code-for-ibmi`)) {
-					connection.loadConfig();
-				}
-			}
-		})
-	)
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(async event => {
+      const connection = instance.getConnection();
+      if (connection) {
+        if (event.affectsConfiguration(`code-for-ibmi.connectionSettings`)) {
+          await connection.loadConfig();
+        }
+      }
+    })
+  )
 }
 
 // this method is called when your extension is deactivated
 function deactivate() {}
 
 module.exports = {
-	activate,
-	deactivate
+  activate,
+  deactivate
 }

--- a/extension.js
+++ b/extension.js
@@ -6,6 +6,8 @@ const vscode = require(`vscode`);
 // your extension is activated the very first time the command is executed
 
 let instance = require(`./src/Instance`);
+const Configuration = require("./src/api/Configuration");
+
 const LoginPanel = require(`./src/webviews/login`);
 
 /**
@@ -36,8 +38,10 @@ function activate(context) {
     vscode.workspace.onDidChangeConfiguration(async event => {
       const connection = instance.getConnection();
       if (connection) {
+        const config = instance.getConfig();
+
         if (event.affectsConfiguration(`code-for-ibmi.connectionSettings`)) {
-          await connection.loadConfig();
+          await config.reload();
         }
       }
     })

--- a/package.json
+++ b/package.json
@@ -64,42 +64,67 @@
 		"configuration": {
 			"title": "Code for IBM i",
 			"properties": {
-				"code-for-ibmi.sourceFileList": {
+				"code-for-ibmi.connectionSettings": {
 					"type": "array",
+					"markdownDescription": "Configurations for different connections.",
 					"items": {
-						"type": "string",
-						"title": "Library and source physical file"
-					},
-					"default": [
-						"QSYSINC/H"
-					],
-					"description": "As seen in the member browser"
+							"type": "object",
+							"description": "Configuration for this connection",
+							"properties": {
+								"host": {
+									"type": "string",
+									"description": "Host for this configuration"
+								},
+
+								"sourceFileList": {
+									"type": "array",
+									"items": {
+										"type": "string",
+										"title": "Library and source physical file"
+									},
+									"default": [
+										"QSYSINC/H"
+									],
+									"description": "As seen in the member browser"
+								},
+
+								"libraryList": {
+									"type": "array",
+									"items": {
+										"type": "string",
+										"title": "Library and source physical file"
+									},
+									"default": ["QSYS2", "QSYSINC"],
+									"description": "Library list. Highest first."
+								},
+
+								"homeDirectory": {
+									"type": "string",
+									"default": ".",
+									"description": "Connection home directory"
+								},
+
+								"temporaryLibrary": {
+									"type": "string",
+									"default": "ILEDITOR",
+									"description": "Temporary library. Cannot be QTEMP."
+								},
+
+								"buildLibrary": {
+									"type": "string",
+									"default": "QTEMP",
+									"description": "Library used for &BUILDLIB when running actions from the IFS."
+								},
+
+								"sourceASP": {
+									"type": ["string"],
+									"default": null,
+									"description": "If source files live within a specific ASP, please specify it here. Leave blank/null otherwise."
+								}
+							}
+					}
 				},
-				"code-for-ibmi.libraryList": {
-					"type": "string",
-					"default": "QSYS2,QSYSINC",
-					"description": "Comma delimited list for the library list"
-				},
-				"code-for-ibmi.homeDirectory": {
-					"type": "string",
-					"default": ".",
-					"description": "Connection home directory"
-				},
-				"code-for-ibmi.temporaryLibrary": {
-					"type": "string",
-					"default": "ILEDITOR",
-					"description": "Temporary library. Cannot be QTEMP."
-				},
-				"code-for-ibmi.buildLibrary": {
-					"type": "string",
-					"default": "QTEMP",
-					"description": "Library used for &BUILDLIB when running actions from the IFS."
-				},
-				"code-for-ibmi.sourceASP": {
-					"type": "string",
-					"default": "",
-					"description": "If source files live within a specific ASP, please specify it here. Leave blank otherwise."
-				},
+
 				"code-for-ibmi.logCompileOutput": {
 					"type": "boolean",
 					"default": false,

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -24,6 +24,7 @@ module.exports = class Instance {
   };
   
   static getConnection() {return instance.connection};
+  static getConfig() {return instance.connection.config};
   static getContent() {return instance.content};
 
   /**
@@ -60,10 +61,12 @@ module.exports = class Instance {
       }
 
 
-      await vscode.commands.executeCommand(`code-for-ibmi.refreshMemberBrowser`);
-      await vscode.commands.executeCommand(`code-for-ibmi.refreshIFSBrowser`);
-      await vscode.commands.executeCommand(`code-for-ibmi.refreshObjectList`);
-      await vscode.commands.executeCommand(`code-for-ibmi.refreshDatabaseBrowser`);
+      await Promise.all([
+        vscode.commands.executeCommand(`code-for-ibmi.refreshMemberBrowser`),
+        vscode.commands.executeCommand(`code-for-ibmi.refreshIFSBrowser`),
+        vscode.commands.executeCommand(`code-for-ibmi.refreshObjectList`),
+        vscode.commands.executeCommand(`code-for-ibmi.refreshDatabaseBrowser`)
+      ]);
     }
 
     return doDisconnect;

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -14,6 +14,9 @@ let initialisedBefore = false;
 let selectedForCompare;
 
 module.exports = class Instance {
+  /** 
+   * @param {IBMi} conn
+   */
   static setConnection(conn) {
     instance.connection = conn;
     instance.content = new IBMiContent(instance.connection);

--- a/src/api/CompileTools.js
+++ b/src/api/CompileTools.js
@@ -99,6 +99,9 @@ module.exports = class CompileTools {
   static async RunAction(instance, uri) {
     let evfeventInfo = {lib: ``, object: ``};
 
+    /** @type {IBMi} */
+    const connection = instance.getConnection();
+
     const config = vscode.workspace.getConfiguration(`code-for-ibmi`);
     const allActions = config.get(`actions`);
 
@@ -132,57 +135,57 @@ module.exports = class CompileTools {
         let basename, name, ext;
 
         switch (uri.scheme) {
-          case `member`:
-            [blank, lib, file, fullName] = uri.path.split(`/`);
-            name = fullName.substring(0, fullName.lastIndexOf(`.`));
+        case `member`:
+          [blank, lib, file, fullName] = uri.path.split(`/`);
+          name = fullName.substring(0, fullName.lastIndexOf(`.`));
 
-            ext = (fullName.includes(`.`) ? fullName.substring(fullName.lastIndexOf(`.`) + 1) : undefined);
+          ext = (fullName.includes(`.`) ? fullName.substring(fullName.lastIndexOf(`.`) + 1) : undefined);
 
-            evfeventInfo = {
-              lib: lib,
-              object: name,
-              ext
-            };
+          evfeventInfo = {
+            lib: lib,
+            object: name,
+            ext
+          };
 
-            command = command.replace(new RegExp(`&OPENLIB`, `g`), lib);
-            command = command.replace(new RegExp(`&OPENSPF`, `g`), file);
-            command = command.replace(new RegExp(`&OPENMBR`, `g`), name);
-            command = command.replace(new RegExp(`&EXT`, `g`), ext);
+          command = command.replace(new RegExp(`&OPENLIB`, `g`), lib);
+          command = command.replace(new RegExp(`&OPENSPF`, `g`), file);
+          command = command.replace(new RegExp(`&OPENMBR`, `g`), name);
+          command = command.replace(new RegExp(`&EXT`, `g`), ext);
 
-            break;
+          break;
 
-          case `streamfile`:
-            basename = path.posix.basename(uri.path);
-            name = basename.substring(0, basename.lastIndexOf(`.`)).toUpperCase();
-            ext = (basename.includes(`.`) ? basename.substring(basename.lastIndexOf(`.`) + 1) : undefined);
+        case `streamfile`:
+          basename = path.posix.basename(uri.path);
+          name = basename.substring(0, basename.lastIndexOf(`.`)).toUpperCase();
+          ext = (basename.includes(`.`) ? basename.substring(basename.lastIndexOf(`.`) + 1) : undefined);
 
-            evfeventInfo = {
-              lib: config.get(`buildLibrary`),
-              object: name,
-              ext
-            };
+          evfeventInfo = {
+            lib: connection.buildLibrary,
+            object: name,
+            ext
+          };
 
-            command = command.replace(new RegExp(`&BUILDLIB`, `g`), config.get(`buildLibrary`));
-            command = command.replace(new RegExp(`&FULLPATH`, `g`), uri.path);
-            command = command.replace(new RegExp(`&NAME`, `g`), name);
-            command = command.replace(new RegExp(`&EXT`, `g`), ext);
+          command = command.replace(new RegExp(`&BUILDLIB`, `g`), connection.buildLibrary);
+          command = command.replace(new RegExp(`&FULLPATH`, `g`), uri.path);
+          command = command.replace(new RegExp(`&NAME`, `g`), name);
+          command = command.replace(new RegExp(`&EXT`, `g`), ext);
 
-            break;
+          break;
 
-          case `object`:
-            [blank, lib, fullName] = uri.path.split(`/`);
-            name = fullName.substring(0, fullName.lastIndexOf(`.`));
+        case `object`:
+          [blank, lib, fullName] = uri.path.split(`/`);
+          name = fullName.substring(0, fullName.lastIndexOf(`.`));
 
-            evfeventInfo = {
-              lib,
-              object: name,
-              extension
-            };
+          evfeventInfo = {
+            lib,
+            object: name,
+            extension
+          };
 
-            command = command.replace(new RegExp(`&LIBRARY`, `g`), lib);
-            command = command.replace(new RegExp(`&NAME`, `g`), name);
-            command = command.replace(new RegExp(`&TYPE`, `g`), extension);
-            break;
+          command = command.replace(new RegExp(`&LIBRARY`, `g`), lib);
+          command = command.replace(new RegExp(`&NAME`, `g`), name);
+          command = command.replace(new RegExp(`&TYPE`, `g`), extension);
+          break;
         }
 
         if (command.startsWith(`?`)) {
@@ -190,8 +193,6 @@ module.exports = class CompileTools {
         }
 
         if (command) {
-          /** @type {IBMi} */
-          const connection = instance.getConnection();
           const libl = connection.libraryList.slice(0).reverse();
           /** @type {any} */
           let commandResult, output;
@@ -202,27 +203,27 @@ module.exports = class CompileTools {
           try {
 
             switch (environment) {
-              case `pase`:
-                commandResult = await connection.paseCommand(command, undefined, 1);
-                break;
+            case `pase`:
+              commandResult = await connection.paseCommand(command, undefined, 1);
+              break;
 
-              case `qsh`:
-                commandResult = await connection.qshCommand([
-                  `liblist -d ` + connection.defaultUserLibraries.join(` `),
-                  `liblist -a ` + libl.join(` `),
-                  command,
-                ], undefined, 1);
-                break;
+            case `qsh`:
+              commandResult = await connection.qshCommand([
+                `liblist -d ` + connection.defaultUserLibraries.join(` `),
+                `liblist -a ` + libl.join(` `),
+                command,
+              ], undefined, 1);
+              break;
 
-              case `ile`:
-              default:
-                command = `system ${connection.logCompileOutput ? `` : `-s`} "${command}"`;
-                commandResult = await connection.qshCommand([
-                  `liblist -d ` + connection.defaultUserLibraries.join(` `),
-                  `liblist -a ` + libl.join(` `),
-                  command,
-                ], undefined, 1);
-                break;
+            case `ile`:
+            default:
+              command = `system ${connection.logCompileOutput ? `` : `-s`} "${command}"`;
+              commandResult = await connection.qshCommand([
+                `liblist -d ` + connection.defaultUserLibraries.join(` `),
+                `liblist -a ` + libl.join(` `),
+                command,
+              ], undefined, 1);
+              break;
             }
 
             if (commandResult.code === 0 || commandResult.code === null) {

--- a/src/api/CompileTools.js
+++ b/src/api/CompileTools.js
@@ -4,6 +4,7 @@ const path = require(`path`);
 
 const errorHandler = require(`./errorHandle`);
 const IBMi = require(`./IBMi`);
+const Configuration = require(`./Configuration`);
 
 const diagnosticSeverity = {
   0: vscode.DiagnosticSeverity.Information,
@@ -102,8 +103,10 @@ module.exports = class CompileTools {
     /** @type {IBMi} */
     const connection = instance.getConnection();
 
-    const config = vscode.workspace.getConfiguration(`code-for-ibmi`);
-    const allActions = config.get(`actions`);
+    /** @type {Configuration} */
+    const config = instance.getConfig();
+
+    const allActions = Configuration.get(`actions`);
 
     const extension = uri.path.substring(uri.path.lastIndexOf(`.`)+1).toUpperCase();
 
@@ -160,12 +163,12 @@ module.exports = class CompileTools {
           ext = (basename.includes(`.`) ? basename.substring(basename.lastIndexOf(`.`) + 1) : undefined);
 
           evfeventInfo = {
-            lib: connection.buildLibrary,
+            lib: config.buildLibrary,
             object: name,
             ext
           };
 
-          command = command.replace(new RegExp(`&BUILDLIB`, `g`), connection.buildLibrary);
+          command = command.replace(new RegExp(`&BUILDLIB`, `g`), config.buildLibrary);
           command = command.replace(new RegExp(`&FULLPATH`, `g`), uri.path);
           command = command.replace(new RegExp(`&NAME`, `g`), name);
           command = command.replace(new RegExp(`&EXT`, `g`), ext);
@@ -193,7 +196,7 @@ module.exports = class CompileTools {
         }
 
         if (command) {
-          const libl = connection.libraryList.slice(0).reverse();
+          const libl = config.libraryList.slice(0).reverse();
           /** @type {any} */
           let commandResult, output;
           let executed = false;
@@ -217,7 +220,7 @@ module.exports = class CompileTools {
 
             case `ile`:
             default:
-              command = `system ${connection.logCompileOutput ? `` : `-s`} "${command}"`;
+              command = `system ${Configuration.get(`logCompileOutput`) ? `` : `-s`} "${command}"`;
               commandResult = await connection.qshCommand([
                 `liblist -d ` + connection.defaultUserLibraries.join(` `),
                 `liblist -a ` + libl.join(` `),

--- a/src/api/Configuration.js
+++ b/src/api/Configuration.js
@@ -1,0 +1,92 @@
+
+const vscode = require(`vscode`);
+
+module.exports = class Configuration {
+  constructor(base = {}) {
+    this.host = base.host;
+
+    /** @type {string[]} LIB/FILE, LIB/FILEs */
+    this.sourceFileList = base.sourceFileList || [`QSYSINC/H`];
+
+    /** @type {string[]} */
+    this.libraryList = base.libraryList || [`QSYS2`, `QSYSINC`];
+
+    /** @type {string} */
+    this.homeDirectory = base.homeDirectory || `.`;
+
+    /** @type {string} */
+    this.tempLibrary = base.tempLibrary || `ILEDITOR`;
+
+    /** @type {string} */
+    this.buildLibrary = base.buildLibrary || `QTEMP`;
+
+    /** @type {string|undefined} */
+    this.sourceASP = base.sourceASP || undefined;
+  }
+
+  /**
+   * Update configuration prop
+   * @param {string} key 
+   * @param {any} value 
+   */
+  async set(key, value) {
+    const globalData = vscode.workspace.getConfiguration(`code-for-ibmi`);
+    let connections = globalData.get(`connectionSettings`);
+
+    const index = connections.findIndex(conn => conn.host === this.host);
+
+    if (index >= 0) {
+      connections[index][key] = value;
+      this[key] = value;
+
+      await globalData.update(`connectionSettings`, connections, vscode.ConfigurationTarget.Global);
+    }
+  }
+
+  /** Reload props from vscode settings */
+  reload() {
+    const globalData = vscode.workspace.getConfiguration(`code-for-ibmi`);
+    const connections = globalData.get(`connectionSettings`);
+    const index = connections.findIndex(conn => conn.host === this.host);
+
+    if (index >= 0) {
+      for (const key in connections[index]) {
+        this[key] = connections[index][key];
+      }
+    }
+  }
+
+  /**
+   * Will load an existing config if it exists, otherwise will create it with default values.
+   * @param {string} host Host string for configuration
+   * @returns {Promise<Configuration>}
+   */
+  static async load(host) {
+    const globalData = vscode.workspace.getConfiguration(`code-for-ibmi`);
+
+    let connections = globalData.get(`connectionSettings`);
+    let existingConfig = connections.find(conn => conn.host === host);
+    let config;
+
+    if (existingConfig) {
+      config = new this(existingConfig);
+
+    } else {
+      config = new this({host});
+      connections.push(config);
+
+      await globalData.update(`connectionSettings`, connections, vscode.ConfigurationTarget.Global);
+    }
+
+    return config;
+  }
+
+  /**
+   * Returns variable not specific to a host (e.g. a global config)
+   * @param {string} prop 
+   */
+  static get(prop) {
+    const globalData = vscode.workspace.getConfiguration(`code-for-ibmi`);
+    return globalData.get(prop);
+  }
+}

--- a/src/api/IBMi.js
+++ b/src/api/IBMi.js
@@ -1,5 +1,6 @@
 const node_ssh = require(`node-ssh`);
 const vscode = require(`vscode`);
+const Configuration = require(`./Configuration`);
 
 module.exports = class IBMi {
   constructor() {
@@ -15,14 +16,6 @@ module.exports = class IBMi {
       db2util: undefined,
       git: undefined
     };
-    
-    //Configration:
-    this.homeDirectory = `.`;
-    this.libraryList = [];
-    this.tempLibrary = `ILEDITOR`;
-    this.spfShortcuts = [`QSYSINC/H`];
-    this.sourceASP = undefined;
-    this.buildLibrary = `QTEMP`;
 
     //Global config
     this.logCompileOutput = false;
@@ -43,22 +36,23 @@ module.exports = class IBMi {
       this.currentPort = connectionObject.port;
       this.currentUser = connectionObject.username;
 
-      await this.loadConfig();
+      /** @type {Configuration} */
+      this.config = await Configuration.load(this.currentHost);
 
       //Perhaps load in existing config if it exists here.
 
       //Continue with finding out info about system
-      if (this.homeDirectory === `.`) await this.set(`homeDirectory`, `/home/${connectionObject.username}`);
+      if (this.config.homeDirectory === `.`) await this.config.set(`homeDirectory`, `/home/${connectionObject.username}`);
 
       //Create home directory if it does not exist.
       try {
-        await this.paseCommand(`mkdir ${this.homeDirectory}`);
+        await this.paseCommand(`mkdir ${this.config.homeDirectory}`);
       } catch (e) {
         //If the folder doesn't exist, then we need to reset the path
         //because we need a valid path for the home directory.
         if (e.indexOf(`File exists`) === -1) {
           //An error message here also?
-          this.homeDirectory = `.`;
+          await this.config.set(`homeDirectory`, `.`);
         }
       }
 
@@ -76,49 +70,49 @@ module.exports = class IBMi {
           type = line.substr(12);
 
           switch (type) {
-            case `USR`:
-              this.defaultUserLibraries.push(lib);
-              break;
+          case `USR`:
+            this.defaultUserLibraries.push(lib);
+            break;
               
-            case `CUR`:
-              currentLibrary = lib;
-              break;
+          case `CUR`:
+            currentLibrary = lib;
+            break;
           }
         }
 
-        if (this.libraryList.length === 0) await this.set(`libraryList`, this.defaultUserLibraries);
+        if (this.config.libraryList.length === 0) await this.config.set(`libraryList`, this.defaultUserLibraries);
       }
 
       //Next, we need to check the temp lib (where temp outfile data lives) exists
       try {
         await this.remoteCommand(
-          `CRTLIB ` + this.tempLibrary,
+          `CRTLIB ` + this.config.tempLibrary,
           undefined,
         );
       } catch (e) {
         let [errorcode, errortext] = e.split(`:`);
 
         switch (errorcode) {
-          case `CPF2111`: //Already exists, hopefully ok :)
-            break;
+        case `CPF2111`: //Already exists, hopefully ok :)
+          break;
           
-          case `CPD0032`: //Can't use CRTLIB
-            try {
-              await this.remoteCommand(
-                `CHKOBJ OBJ(QSYS/${this.tempLibrary}) OBJTYPE(*LIB)`,
-                undefined
-              );
+        case `CPD0032`: //Can't use CRTLIB
+          try {
+            await this.remoteCommand(
+              `CHKOBJ OBJ(QSYS/${this.config.tempLibrary}) OBJTYPE(*LIB)`,
+              undefined
+            );
 
-              //We're all good if no errors
-            } catch (e) {
-              if (currentLibrary.startsWith(`Q`)) {
-                //Temporary library not created. Some parts of the extension will not run without a temporary library.
-              } else {
-                this.tempLibrary = currentLibrary;
-                //Using ${currentLibrary} as the temporary library for temporary data.
-              }
+            //We're all good if no errors
+          } catch (e) {
+            if (currentLibrary.startsWith(`Q`)) {
+              //Temporary library not created. Some parts of the extension will not run without a temporary library.
+            } else {
+              this.config.tempLibrary = currentLibrary;
+              //Using ${currentLibrary} as the temporary library for temporary data.
             }
-            break;
+          }
+          break;
         }
 
         console.log(e);
@@ -146,62 +140,6 @@ module.exports = class IBMi {
   }
 
   /**
-   * Update connection settings
-   * @param {string} string 
-   * @param {any} value 
-   */
-  async set(string, value) {
-    const globalData = vscode.workspace.getConfiguration(`code-for-ibmi`);
-    let connections = globalData.get(`connectionSettings`);
-
-    const index = connections.findIndex(conn => conn.host === this.currentHost);
-
-    if (index >= 0) {
-      connections[index][string] = value;
-      this[string] = value;
-
-      await globalData.update(`connectionSettings`, connections, vscode.ConfigurationTarget.Global);
-    }
-  }
-  
-  /**
-   * Load configuration from vscode.
-   */
-  async loadConfig() {
-    const globalData = vscode.workspace.getConfiguration(`code-for-ibmi`);
-
-    let connections = globalData.get(`connectionSettings`);
-
-    if (!connections.find(conn => conn.host === this.currentHost)) {
-      //Defaults
-      connections.push({
-        "host": this.currentHost,
-        "sourceFileList": [`QSYSINC/H`],
-        "libraryList": `QSYS2,QSYSINC`,
-        "homeDirectory": `homeDirectory`,
-        "temporaryLibrary": `ILEDITOR`,
-        "buildLibrary": `QTEMP`,
-        "sourceASP": null
-      });
-
-      await globalData.update(`connectionSettings`, connections, vscode.ConfigurationTarget.Global);
-    }
-
-    let connectionConfig = connections.find(conn => conn.host === this.currentHost);
-
-    //Connection settings
-    this.spfShortcuts = connectionConfig[`sourceFileList`];
-    this.libraryList = connectionConfig[`libraryList`].split(`,`).map(item => item.trim());
-    this.homeDirectory = connectionConfig[`homeDirectory`];
-    this.tempLibrary = connectionConfig[`temporaryLibrary`];
-    this.sourceASP = (connectionConfig[`sourceASP`] ? connectionConfig[`sourceASP`] : undefined);
-
-    //Editor settings
-    this.logCompileOutput = globalData.get(`logCompileOutput`) || false;
-    this.autoRefresh = globalData.get(`autoRefresh`);
-  }
-
-  /**
    * 
    * @param {string} command 
    * @param {string} [directory] If not passed, will use current home directory
@@ -217,7 +155,7 @@ module.exports = class IBMi {
    * @param {string} [directory] 
    * @param {number} [returnType] 
    */
-  qshCommand(command, directory = this.homeDirectory, returnType = 0) {
+  qshCommand(command, directory = this.config.homeDirectory, returnType = 0) {
 
     if (Array.isArray(command)) {
       command = command.join(`;`);
@@ -236,7 +174,7 @@ module.exports = class IBMi {
    * @param {null|string} [directory] If null/not passed, will default to home directory
    * @param {number} [returnType] If not passed, will default to 0. Accepts 0 or 1
    */
-  async paseCommand(command, directory = this.homeDirectory, returnType = 0) {
+  async paseCommand(command, directory = this.config.homeDirectory, returnType = 0) {
     command = command.replace(/\$/g, `\\$`);
 
     let result = await this.client.execCommand(command, {

--- a/src/api/IBMiContent.js
+++ b/src/api/IBMiContent.js
@@ -45,7 +45,7 @@ module.exports = class IBMiContent {
    * @param {string} mbr 
    */
   async downloadMemberContent(asp, lib, spf, mbr) {
-    if (!asp) asp = this.ibmi.sourceASP;
+    if (!asp) asp = this.ibmi.config.sourceASP;
     lib = lib.toUpperCase();
     spf = spf.toUpperCase();
     mbr = mbr.toUpperCase();
@@ -93,7 +93,7 @@ module.exports = class IBMiContent {
    * @param {string} content 
    */
   async uploadMemberContent(asp, lib, spf, mbr, content) {
-    if (!asp) asp = this.ibmi.sourceASP;
+    if (!asp) asp = this.ibmi.config.sourceASP;
     lib = lib.toUpperCase();
     spf = spf.toUpperCase();
     mbr = mbr.toUpperCase();
@@ -188,7 +188,7 @@ module.exports = class IBMiContent {
   async getObjectList(lib) {
     lib = lib.toUpperCase();
 
-    const tempLib = this.ibmi.tempLibrary;
+    const tempLib = this.ibmi.config.tempLibrary;
     const TempName = IBMi.makeid();
 
     await this.ibmi.remoteCommand(`DSPOBJD OBJ(${lib}/*ALL) OBJTYPE(*ALL) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${TempName})`);
@@ -218,7 +218,7 @@ module.exports = class IBMiContent {
     lib = lib.toUpperCase();
     spf = spf.toUpperCase();
 
-    const tempLib = this.ibmi.tempLibrary;
+    const tempLib = this.ibmi.config.tempLibrary;
     const TempName = IBMi.makeid();
 
     await this.ibmi.remoteCommand(`DSPFD FILE(${lib}/${spf}) TYPE(*MBR) OUTPUT(*OUTFILE) OUTFILE(${tempLib}/${TempName})`);

--- a/src/views/databaseBrowser.js
+++ b/src/views/databaseBrowser.js
@@ -16,13 +16,6 @@ module.exports = class databaseBrowserProvider {
     this.onDidChangeTreeData = this.emitter.event;
 
     context.subscriptions.push(
-      vscode.workspace.onDidChangeConfiguration(event => {
-        let affected = event.affectsConfiguration(`code-for-ibmi.libraryList`);
-        if (affected) {
-          this.refresh();
-        }
-      }),
-
       vscode.commands.registerCommand(`code-for-ibmi.refreshDatabaseBrowser`, async () => {
         this.refresh();
       }),

--- a/src/views/databaseBrowser.js
+++ b/src/views/databaseBrowser.js
@@ -137,8 +137,10 @@ module.exports = class databaseBrowserProvider {
     } else {
       const connection = instance.getConnection();
       if (connection) {
+        const config = instance.getConfig();
+        
         if (connection.remoteFeatures.db2util) {
-          const libraries = connection.libraryList;
+          const libraries = config.libraryList;
 
           for (let library of libraries) {
             items.push(new SchemaItem(library));
@@ -234,21 +236,21 @@ function parseStatement(editor) {
 
     for (const c of text) {
       switch (c) {
-        case `'`:
-          inQuote = !inQuote;
-          break;
+      case `'`:
+        inQuote = !inQuote;
+        break;
         
-        case `;`:
-          if (!inQuote) {
-            statements.push({
-              start,
-              end,
-              text: text.substring(start, end)
-            });
+      case `;`:
+        if (!inQuote) {
+          statements.push({
+            start,
+            end,
+            text: text.substring(start, end)
+          });
 
-            start = end+1;
-          }
-          break;
+          start = end+1;
+        }
+        break;
       }
       end++;
     }

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -3,6 +3,7 @@ const { throws } = require(`assert`);
 const vscode = require(`vscode`);
 
 let instance = require(`../Instance`);
+const Configuration = require(`../api/Configuration`);
 
 module.exports = class ifsBrowserProvider {
   /**
@@ -20,7 +21,8 @@ module.exports = class ifsBrowserProvider {
 
       vscode.commands.registerCommand(`code-for-ibmi.changeHomeDirectory`, async () => {
         const connection = instance.getConnection();
-        const homeDirectory = connection.homeDirectory;
+        const config = instance.getConfig();
+        const homeDirectory = config.homeDirectory;
 
         const newDirectory = await vscode.window.showInputBox({
           prompt: `Changing home directory`,
@@ -29,9 +31,9 @@ module.exports = class ifsBrowserProvider {
 
         try {
           if (newDirectory && newDirectory !== homeDirectory) {
-            await connection.set(`homeDirectory`, newDirectory);
+            await config.set(`homeDirectory`, newDirectory);
             
-            if (connection.autoRefresh) this.refresh();
+            if (Configuration.get(`autoRefresh`)) this.refresh();
           }
         } catch (e) {
           console.log(e);
@@ -41,6 +43,7 @@ module.exports = class ifsBrowserProvider {
 
       vscode.commands.registerCommand(`code-for-ibmi.createDirectory`, async (node) => {
         const connection = instance.getConnection();
+        const config = instance.getConfig();
         let root;
 
         if (node) {
@@ -48,7 +51,7 @@ module.exports = class ifsBrowserProvider {
           
           root = node.path;
         } else {
-          root = connection.homeDirectory;
+          root = config.homeDirectory;
         }
 
         const fullName = await vscode.window.showInputBox({
@@ -61,7 +64,7 @@ module.exports = class ifsBrowserProvider {
           try {
             await connection.paseCommand(`mkdir ${fullName}`);
 
-            if (connection.autoRefresh) this.refresh();
+            if (Configuration.get(`autoRefresh`)) this.refresh();
 
           } catch (e) {
             vscode.window.showErrorMessage(`Error creating new directory! ${e}`);
@@ -71,6 +74,7 @@ module.exports = class ifsBrowserProvider {
 
       vscode.commands.registerCommand(`code-for-ibmi.createStreamfile`, async (node) => {
         const connection = instance.getConnection();
+        const config = instance.getConfig();
         let root;
 
         if (node) {
@@ -78,7 +82,7 @@ module.exports = class ifsBrowserProvider {
           
           root = node.path;
         } else {
-          root = connection.homeDirectory;
+          root = config.homeDirectory;
         }
         
         const fullName = await vscode.window.showInputBox({
@@ -96,7 +100,7 @@ module.exports = class ifsBrowserProvider {
 
             vscode.commands.executeCommand(`code-for-ibmi.openEditable`, fullName);
 
-            if (connection.autoRefresh) this.refresh();
+            if (Configuration.get(`autoRefresh`)) this.refresh();
 
           } catch (e) {
             vscode.window.showErrorMessage(`Error creating new streamfile! ${e}`);
@@ -125,7 +129,7 @@ module.exports = class ifsBrowserProvider {
 
                 vscode.window.showInformationMessage(`Deleted ${node.path}.`);
 
-                if (connection.autoRefresh) this.refresh();
+                if (Configuration.get(`autoRefresh`)) this.refresh();
               } catch (e) {
                 vscode.window.showErrorMessage(`Error deleting streamfile! ${e}`);
               }
@@ -157,7 +161,7 @@ module.exports = class ifsBrowserProvider {
 
               try {
                 await connection.paseCommand(`mv ${node.path} ${fullName}`);
-                if (connection.autoRefresh) this.refresh();
+                if (Configuration.get(`autoRefresh`)) this.refresh();
 
               } catch (e) {
                 vscode.window.showErrorMessage(`Error moving streamfile! ${e}`);
@@ -196,6 +200,8 @@ module.exports = class ifsBrowserProvider {
     let items = [], item;
 
     if (connection) {
+      const config = instance.getConfig();
+      
       if (element) { //Chosen SPF
         //Fetch members
         console.log(element.path);
@@ -215,7 +221,7 @@ module.exports = class ifsBrowserProvider {
         }
 
       } else {
-        const objects = await content.getFileList(connection.homeDirectory);
+        const objects = await content.getFileList(config.homeDirectory);
 
         for (let object of objects) {
           items.push(new Object(object.type, object.name, object.path));

--- a/src/views/memberBrowser.js
+++ b/src/views/memberBrowser.js
@@ -2,6 +2,7 @@
 const vscode = require(`vscode`);
 
 let instance = require(`../Instance`);
+const Configuration = require(`../api/Configuration`);
 
 module.exports = class memberBrowserProvider {
   /**
@@ -24,7 +25,9 @@ module.exports = class memberBrowserProvider {
 
       vscode.commands.registerCommand(`code-for-ibmi.addSourceFile`, async () => {
         const connection = instance.getConnection();
-        let sourceFiles = connection.spfShortcuts;
+        const config = instance.getConfig();
+
+        let sourceFiles = config.sourceFileList;
 
         const newSourceFile = await vscode.window.showInputBox({
           prompt: `Source file to add (Format: LIB/FILE)`
@@ -33,8 +36,8 @@ module.exports = class memberBrowserProvider {
         if (newSourceFile) {
           if (newSourceFile.includes(`/`)) {
             sourceFiles.push(newSourceFile.toUpperCase());
-            await connection.set(`sourceFileList`, sourceFiles);
-            if (connection.autoRefresh) this.refresh();
+            await config.set(`sourceFileList`, sourceFiles);
+            if (Configuration.get(`autoRefresh`)) this.refresh();
           } else {
             vscode.window.showErrorMessage(`Format incorrect. Use LIB/FILE.`);
           }
@@ -45,15 +48,17 @@ module.exports = class memberBrowserProvider {
         if (node) {
           //Running from right click
           const connection = instance.getConnection();
-          let sourceFiles = connection.spfShortcuts;
+          const config = instance.getConfig();
+
+          let sourceFiles = config.sourceFileList;
 
           let index = sourceFiles.findIndex(file => file.toUpperCase() === node.path)
           if (index >= 0) {
             sourceFiles.splice(index, 1);
           }
 
-          await connection.set(`sourceFileList`, sourceFiles);
-          if (connection.autoRefresh) this.refresh();
+          await config.set(`sourceFileList`, sourceFiles);
+          if (Configuration.get(`autoRefresh`)) this.refresh();
         }
       }),
 
@@ -91,7 +96,7 @@ module.exports = class memberBrowserProvider {
 
                 vscode.commands.executeCommand(`code-for-ibmi.openEditable`, uriPath);
 
-                if (connection.autoRefresh) {
+                if (Configuration.get(`autoRefresh`)) {
                   this.refresh(path[0], path[1]);
                 }
               } catch (e) {
@@ -136,7 +141,7 @@ module.exports = class memberBrowserProvider {
 
                 vscode.commands.executeCommand(`code-for-ibmi.openEditable`, fullPath);
 
-                if (connection.autoRefresh) {
+                if (Configuration.get(`autoRefresh`)) {
                   this.refresh(oldPath[0], oldPath[1]);
                   this.refresh(newPath[0], newPath[1]);
                 }
@@ -177,7 +182,7 @@ module.exports = class memberBrowserProvider {
 
                 vscode.window.showInformationMessage(`Deleted ${node.path}.`);
 
-                if (connection.autoRefresh) {
+                if (Configuration.get(`autoRefresh`)) {
                   this.refresh(path[0], path[1]);
                 }
               } catch (e) {
@@ -210,7 +215,7 @@ module.exports = class memberBrowserProvider {
                 `CHGPFM FILE(${path[0]}/${path[1]}) MBR(${name}) TEXT('${newText}')`,
               );
 
-              if (connection.autoRefresh) {
+              if (Configuration.get(`autoRefresh`)) {
                 this.refresh(path[0], path[1]);
               }
             } catch (e) {
@@ -262,7 +267,7 @@ module.exports = class memberBrowserProvider {
                     );
                   }
     
-                  if (connection.autoRefresh) {
+                  if (Configuration.get(`autoRefresh`)) {
                     this.refresh(path[0], path[1]);
                   }
                   else vscode.window.showInformationMessage(`Renamed member. Reload required.`);
@@ -340,8 +345,10 @@ module.exports = class memberBrowserProvider {
       }
     } else {
       const connection = instance.getConnection();
+
       if (connection) {
-        const shortcuts = connection.spfShortcuts;
+        const config = instance.getConfig();
+        const shortcuts = config.sourceFileList;
 
         for (let shortcut of shortcuts) {
           shortcut = shortcut.toUpperCase();

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -93,8 +93,10 @@ module.exports = class objectBrowserProvider {
       }
     } else {
       const connection = instance.getConnection();
+
       if (connection) {
-        const libraries = connection.libraryList;
+        const config = instance.getConfig();
+        const libraries = config.libraryList;
 
         for (let library of libraries) {
           library = library.toUpperCase();

--- a/src/views/objectBrowser.js
+++ b/src/views/objectBrowser.js
@@ -19,13 +19,6 @@ module.exports = class objectBrowserProvider {
     this.refreshCache = {};
 
     context.subscriptions.push(
-      vscode.workspace.onDidChangeConfiguration(event => {
-        let affected = event.affectsConfiguration(`code-for-ibmi.libraryList`);
-        if (affected) {
-          this.refresh();
-        }
-      }),
-
       vscode.commands.registerCommand(`code-for-ibmi.refreshObjectList`, async (library) => {
         if (library) {
           if (typeof library === `string`) {

--- a/src/webviews/login/index.js
+++ b/src/webviews/login/index.js
@@ -36,43 +36,43 @@ module.exports = class Login {
     panel.webview.onDidReceiveMessage(
       async message => {
         switch (message.command) {
-          case `login`:
-            message.data.port = Number(message.data.port);
+        case `login`:
+          message.data.port = Number(message.data.port);
 
-            vscode.window.showInformationMessage(`Connecting to ${message.data.host}.`);
+          vscode.window.showInformationMessage(`Connecting to ${message.data.host}.`);
 
-            const connection = new IBMi();
+          const connection = new IBMi();
 
-            try {
-              const connected = await connection.connect(message.data);
-              if (connected) {
-                panel.dispose();
+          try {
+            const connected = await connection.connect(message.data);
+            if (connected) {
+              panel.dispose();
 
-                vscode.window.showInformationMessage(`Connected to ${message.data.host}!`);
+              vscode.window.showInformationMessage(`Connected to ${message.data.host}!`);
 
-                instance.setConnection(connection);
-                instance.loadAllofExtension(context);
+              instance.setConnection(connection);
+              instance.loadAllofExtension(context);
 
-                let existingConnectionsConfig = vscode.workspace.getConfiguration(`code-for-ibmi`);
-                let existingConnections = existingConnectionsConfig.get(`connections`);
-                if (!existingConnections.find(item => item.host === message.data.host)) {
-                  existingConnections.push({
-                    host: message.data.host,
-                    port: message.data.port,
-                    username: message.data.username
-                  });
-                  await existingConnectionsConfig.update(`connections`, existingConnections, vscode.ConfigurationTarget.Global);
-                }
-
-              } else {
-                vscode.window.showErrorMessage(`Not connected to ${message.data.host}!`);
+              let existingConnectionsConfig = vscode.workspace.getConfiguration(`code-for-ibmi`);
+              let existingConnections = existingConnectionsConfig.get(`connections`);
+              if (!existingConnections.find(item => item.host === message.data.host)) {
+                existingConnections.push({
+                  host: message.data.host,
+                  port: message.data.port,
+                  username: message.data.username
+                });
+                await existingConnectionsConfig.update(`connections`, existingConnections, vscode.ConfigurationTarget.Global);
               }
 
-            } catch (e) {
-              vscode.window.showErrorMessage(`Error connecting to ${message.data.host}! ${e.message}`);
+            } else {
+              vscode.window.showErrorMessage(`Not connected to ${message.data.host}!`);
             }
 
-            return;
+          } catch (e) {
+            vscode.window.showErrorMessage(`Error connecting to ${message.data.host}! ${e.message}`);
+          }
+
+          return;
         }
       },
       undefined,


### PR DESCRIPTION
### Changes

This is a very large change and was required in order to support having different configurations per system. This makes it much easier to manage configs as it no longer uses the vscode API through out the extension, just now in one place.

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in the README
