### PR TITLE
Correct field name on login form

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Maintain your RPGLE, CL, COBOL, C/CPP on IBM i right from Visual Studio Code.
 * [@thebeardedgeek](https://github.com/thebeardedgeek)
 * [@dferrand](https://github.com/dferrand)
 * [@dariocs](https://github.com/dariocs)
+* [@priceaj](https://github.com/priceaj)
 
 ## Features
 

--- a/src/webviews/login/index.js
+++ b/src/webviews/login/index.js
@@ -20,7 +20,7 @@ module.exports = class Login {
     let ui = new CustomUI();
 
     ui.addField(new Field(`input`, `host`, `Host or IP Address`));
-    ui.addField(new Field(`input`, `port`, `Host or IP Address`));
+    ui.addField(new Field(`input`, `port`, `Port`));
     ui.fields[1].default = `22`;
     ui.addField(new Field(`input`, `username`, `Username`));
     ui.addField(new Field(`password`, `password`, `Password`));


### PR DESCRIPTION
### Changes

Correct port field on login to be named port.

### Checklist

* [X] have tested my change
* [X] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [X] have added myself to the contributors' list in the README
