### PR TITLE
Add option to connect with SSH private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,6 @@ Maintain your RPGLE, CL, COBOL, C/CPP on IBM i right from Visual Studio Code.
 
 ![](media/image.png)
 
-## Contributors
-
-* [@connorholyday](https://github.com/connorholyday)
-* [@worksofliam](https://github.com/worksofliam)
-* [@alanseiden](https://github.com/alanseiden)
-* [@richardschoen](https://github.com/richardschoen)
-* [@barrettotte](https://github.com/barrettotte)
-* [@thebeardedgeek](https://github.com/thebeardedgeek)
-* [@dferrand](https://github.com/dferrand)
-* [@dariocs](https://github.com/dariocs)
-* [@priceaj](https://github.com/priceaj)
-* [@sgi495](https://github.com/sgi495)
-* [@SJLennon](https://github.com/SJLennon)
-
 ## Features
 
 * Member browser and editor
@@ -78,3 +64,18 @@ You can click on a member to open and edit it. There is no member locking and th
 
 ## Detailed Documentation
 More detailed documentation is available [here](https://halcyon-tech.github.io/code-for-ibmi/#/)
+
+## Contributors
+
+* [@connorholyday](https://github.com/connorholyday)
+* [@worksofliam](https://github.com/worksofliam)
+* [@alanseiden](https://github.com/alanseiden)
+* [@richardschoen](https://github.com/richardschoen)
+* [@barrettotte](https://github.com/barrettotte)
+* [@thebeardedgeek](https://github.com/thebeardedgeek)
+* [@dferrand](https://github.com/dferrand)
+* [@dariocs](https://github.com/dariocs)
+* [@priceaj](https://github.com/priceaj)
+* [@sgi495](https://github.com/sgi495)
+* [@SJLennon](https://github.com/SJLennon)
+* [@onewheelonly](https://github.com/onewheelonly)

--- a/docs/README.md
+++ b/docs/README.md
@@ -161,7 +161,8 @@ Here is a snippet of what the connection details look like:
   {
     "host": "DEV400",
     "port": 22,
-    "username": "OTTEB"
+    "username": "OTTEB",
+    "privateKey": null
   }
 ],
 ```

--- a/src/api/IBMi.js
+++ b/src/api/IBMi.js
@@ -27,13 +27,16 @@ module.exports = class IBMi {
   }
 
   /**
-   * @param {{host: string, port: number, username: string, password: string, keepaliveInterval?: number}} connectionObject 
+   * @param {{host: string, port: number, username: string, password?: string,
+   *          privateKey?: string, keepaliveInterval?: number}} connectionObject
    * @returns {Promise<{success: boolean, error?: any}>} Was succesful at connecting or not.
    */
   async connect(connectionObject) {
     try {
       connectionObject.keepaliveInterval = 35000;
-
+      // Make sure we're not passing any blank strings, as node_ssh will try to validate it
+      if (!connectionObject.privateKey) (connectionObject.privateKey = null);
+      
       await this.client.connect(connectionObject);
 
       this.currentHost = connectionObject.host;

--- a/src/webviews/login/index.js
+++ b/src/webviews/login/index.js
@@ -24,6 +24,7 @@ module.exports = class Login {
     ui.fields[1].default = `22`;
     ui.addField(new Field(`input`, `username`, `Username`));
     ui.addField(new Field(`password`, `password`, `Password`));
+    ui.addField(new Field(`input`, `privateKey`, `Path to Private Key`));
     ui.addField(new Field(`submit`, `submitButton`, `Connect`));
 
     const {panel, data} = await ui.loadPage(`IBM i Login`);
@@ -50,7 +51,8 @@ module.exports = class Login {
             existingConnections.push({
               host: data.host,
               port: data.port,
-              username: data.username
+              username: data.username,
+              privateKey: data.privateKey
             });
             await existingConnectionsConfig.update(`connections`, existingConnections, vscode.ConfigurationTarget.Global);
           }
@@ -81,38 +83,46 @@ module.exports = class Login {
     }
 
     const existingConnectionsConfig = vscode.workspace.getConfiguration(`code-for-ibmi`);
-    const existingConnections = existingConnectionsConfig.get(`connections`);
-    const items = existingConnections.map(item => `${item.username}@${item.host}:${item.port}`);
+    const existingConnections = existingConnectionsConfig
+      .get(`connections`)
+      .map(item => ({
+        label: `${item.username}@${item.host}:${item.port}`,
+        config: item
+      }));
 
-    const selected = await vscode.window.showQuickPick(items, {canPickMany: false});
+    const selected = await vscode.window.showQuickPick(existingConnections, {canPickMany: false});
 
     if (selected) {
-      const [username, hostname] = selected.split(`@`);
-      const [host, port] = hostname.split(`:`);
+      let connectionConfig = selected[`config`];
 
-      const password = await vscode.window.showInputBox({
-        prompt: `Password for ${selected}`,
-        password: true
-      });
-
-      if (password) {
-        const connection = new IBMi();
-
-        try {
-          const connected = await connection.connect({host, port: Number(port), username, password});
-          if (connected.success) {
-            vscode.window.showInformationMessage(`Connected to ${host}!`);
-
-            instance.setConnection(connection);
-            instance.loadAllofExtension(context);
-
-          } else {
-            vscode.window.showErrorMessage(`Not connected to ${host}! ${connected.error.message || connected.error}`);
-          }
-        } catch (e) {
-          vscode.window.showErrorMessage(`Error connecting to ${host}! ${e.message}`);
+      if (!connectionConfig.privateKey) {
+        connectionConfig.password = await vscode.window.showInputBox({
+          prompt: `Password for ${selected[`label`]}`,
+          password: true
+        });
+        
+        if (!connectionConfig.password) {
+          return;
         }
+      }
+
+      const connection = new IBMi();
+
+      try {
+        const connected = await connection.connect(connectionConfig);
+        if (connected.success) {
+          vscode.window.showInformationMessage(`Connected to ${connectionConfig.host}!`);
+
+          instance.setConnection(connection);
+          instance.loadAllofExtension(context);
+
+        } else {
+          vscode.window.showErrorMessage(`Not connected to ${connectionConfig.host}! ${connected.error.message || connected.error}`);
+        }
+      } catch (e) {
+        vscode.window.showErrorMessage(`Error connecting to ${connectionConfig.host}! ${e.message}`);
       }
     }
   }
+  
 }


### PR DESCRIPTION
### Changes

Simple attempt to introduce connectivity with SSH private keys. I've only tested on Windows, but I've no reason to believe that this shouldn't work on Linux/Mac as well.

Limitations: this won't be useful for SSH keys protected with a passcode.

`docs/README.md` could use a couple of updated screenshots for the connection window (i.e. `login_03.png` and `login_04.png` in `docs/assets/`). I've omitted them for now, as the look and feel of my editor wouldn't be consistent with the rest of the document. Could you possibly add them in for me please?

I've also bumped the list of contributors to the bottom of the main README. Controversial, I know! However, it was getting so long that it obscures the useful information a first time reader would want to see. I can restore this to its original state if you prefer.

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in the README
