### PR TITLE
&BUILDLIB for member actions and library list

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -102,12 +102,13 @@ Notice the special identifiers in the command begining with `&`. These identifie
 | &OPENSPF | Source file that member resides in |
 | &OPENMBR | Name of member                     |
 | &EXT     | Member extension                   |
+| &BUILDLIB | Values which comes from the connection settings |
 
 #### Streamfile variables
 
 | Variable  | Usage                                           |
 |-----------|-------------------------------------------------|
-| &BUILDLIB | Values which comes from Code for IBM i settings |
+| &BUILDLIB | Values which comes from the connection settings |
 | &FULLPATH | Path to the streamfile.                         |
 | &NAME     | Name of the streamfile with no extension        |
 | &EXT      | Extension of basename                           |
@@ -201,7 +202,15 @@ An array of objects. Each object is unique by the host property and is used so d
 Source files to be included in the member browser.
 
 #### Library List
-An array for the library list. Highest item of the library list goes first.
+An array for the library list. Highest item of the library list goes first. You are able to use `&BUILDLIB` in the library list, to make compiles dynamic.
+
+```json
+"libraryList": [
+    "&BUILDLIB",
+    "DATALIB",
+    "QSYSINC"
+]
+```
 
 #### Home Directory
 Home directory for user. This directory is also the root for the IFS browser.
@@ -210,7 +219,7 @@ Home directory for user. This directory is also the root for the IFS browser.
 Temporary library. Is used OUTPUT files. Cannot be QTEMP.
 
 #### Build library
-A library that can be defined/changes for IFS builds.
+A library that can be defined/changes for IFS builds. You can also change the build library with the 'Change build library' command (F1 -> Change build library).
 
 #### Source ASP
 If source files are located in a specific ASP, specify here. 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"onCommand:code-for-ibmi.openEditable",
 		"onCommand:code-for-ibmi.selectForCompare",
 		"onCommand:code-for-ibmi.compareWithSelected",
+		"onCommand:code-for-ibmi.changeBuildLibrary",
 		"onView:memberBrowser",
 		"onCommand:code-for-ibmi.refreshMemberBrowser",
 		"onCommand:code-for-ibmi.createMember",
@@ -436,6 +437,11 @@
 			{
 				"command": "code-for-ibmi.compareWithSelected",
 				"title": "Compare with Selected",
+				"category": "IBM i"
+			},
+			{
+				"command": "code-for-ibmi.changeBuildLibrary",
+				"title": "Change build library",
 				"category": "IBM i"
 			},
 			{

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -210,6 +210,26 @@ module.exports = class Instance {
             }
           })
         );
+
+        context.subscriptions.push(
+          vscode.commands.registerCommand(`code-for-ibmi.changeBuildLibrary`, async () => {
+            const config = this.getConfig();
+            const buildLibrary = config.buildLibrary.toUpperCase();
+    
+            const newLibrary = await vscode.window.showInputBox({
+              prompt: `Changing build library`,
+              value: buildLibrary
+            });
+    
+            try {
+              if (newLibrary && newLibrary !== buildLibrary) {
+                await config.set(`buildLibrary`, newLibrary);
+              }
+            } catch (e) {
+              console.log(e);
+            }
+          })
+        );
         
         new rpgleLinter(context);
 

--- a/src/api/CompileTools.js
+++ b/src/api/CompileTools.js
@@ -137,6 +137,8 @@ module.exports = class CompileTools {
         command = availableActions.find(action => action.name === chosenOptionName).command;
         environment = availableActions.find(action => action.name === chosenOptionName).environment || `ile`;
 
+        command = command.replace(new RegExp(`&BUILDLIB`, `g`), config.buildLibrary);
+
         let blank, asp, lib, file, fullName;
         let basename, name, ext;
 
@@ -184,7 +186,6 @@ module.exports = class CompileTools {
             ext
           };
 
-          command = command.replace(new RegExp(`&BUILDLIB`, `g`), config.buildLibrary);
           command = command.replace(new RegExp(`&FULLPATH`, `g`), uri.path);
           command = command.replace(new RegExp(`&NAME`, `g`), name);
           command = command.replace(new RegExp(`&EXT`, `g`), ext);
@@ -215,11 +216,22 @@ module.exports = class CompileTools {
         }
 
         if (command) {
-          const libl = config.libraryList.slice(0).reverse();
           /** @type {any} */
           let commandResult, output;
           let executed = false;
 
+          //We have to reverse it because `liblist -a` adds the next item to the top always 
+          let libl = config.libraryList.slice(0).reverse();
+
+          libl = libl.map(library => {
+            //We use this for special variables in the libl
+            switch (library) {
+            case `&BUILDLIB`: return config.buildLibrary;
+            default: return library;
+            }
+          });
+
+          outputChannel.append(`Library list: ` + libl.reverse().join(` `) + `\n`);
           outputChannel.append(`Command: ` + command + `\n`);
 
           try {


### PR DESCRIPTION
### Changes

Solves #98 

* able to use `&BUILDLIB` in Member actions and the library list.
* new command to change build library
* print library list to output channel when running an action

### Checklist

* [X] have tested my change
* [X] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [X] have added myself to the contributors' list in the README
