### PR TITLE
Add CRTCMD for streamfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,4 @@ More detailed documentation is available [here](https://halcyon-tech.github.io/c
 * [@sgi495](https://github.com/sgi495)
 * [@SJLennon](https://github.com/SJLennon)
 * [@onewheelonly](https://github.com/onewheelonly)
+* [@chrjorgensen](https://github.com/chrjorgensen)

--- a/package.json
+++ b/package.json
@@ -286,7 +286,7 @@
 								"CMD"
 							],
 							"name": "Create Command (CRTCMD)",
-							"command": "?CRTCMD CMD(&OPENLIB/&OPNMBR) PGM(&OPNLIB/&OPNMBRC) SRCFILE(&OPENLIB/&OPENSPF) ALLOW(*ALL) CURLIB(*NOCHG) PRDLIB(*NOCHG)"
+							"command": "?CRTCMD CMD(&OPENLIB/&OPENMBR) PGM(&OPNLIB/&OPENMBRC) SRCFILE(&OPENLIB/&OPENSPF) ALLOW(*ALL) CURLIB(*NOCHG) PRDLIB(*NOCHG)"
 						},
 						{
 							"type": "member",
@@ -294,7 +294,7 @@
 								"CMD"
 							],
 							"name": "Create Command (Allow Return Variables - CRTCMD)",
-							"command": "?CRTCMD CMD(&OPENLIB/&OPNMBR) PGM(&OPNLIB/&OPNMBRC) SRCFILE(&OPENLIB/&OPENSPF) ALLOW(ALLOW(*BPGM *IPGM *BMOD *IMOD) ) CURLIB(*NOCHG) PRDLIB(*NOCHG)"
+							"command": "?CRTCMD CMD(&OPENLIB/&OPENMBR) PGM(&OPNLIB/&OPENMBRC) SRCFILE(&OPENLIB/&OPENSPF) ALLOW(ALLOW(*BPGM *IPGM *BMOD *IMOD) ) CURLIB(*NOCHG) PRDLIB(*NOCHG)"
 						},
 						{
 							"type": "member",

--- a/package.json
+++ b/package.json
@@ -286,7 +286,7 @@
 								"CMD"
 							],
 							"name": "Create Command (CRTCMD)",
-							"command": "?CRTCMD CMD(&OPENLIB/&OPENMBR) PGM(&OPENLIB/&OPENMBRC) SRCFILE(&OPENLIB/&OPENSPF) ALLOW(*ALL) CURLIB(*NOCHG) PRDLIB(*NOCHG)"
+							"command": "?CRTCMD CMD(&OPENLIB/&OPENMBR) PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) ALLOW(*ALL) CURLIB(*NOCHG) PRDLIB(*NOCHG)"
 						},
 						{
 							"type": "member",
@@ -294,7 +294,7 @@
 								"CMD"
 							],
 							"name": "Create Command (Allow Return Variables - CRTCMD)",
-							"command": "?CRTCMD CMD(&OPENLIB/&OPENMBR) PGM(&OPENLIB/&OPENMBRC) SRCFILE(&OPENLIB/&OPENSPF) ALLOW(ALLOW(*BPGM *IPGM *BMOD *IMOD) ) CURLIB(*NOCHG) PRDLIB(*NOCHG)"
+							"command": "?CRTCMD CMD(&OPENLIB/&OPENMBR) PGM(&OPENLIB/&OPENMBR) SRCFILE(&OPENLIB/&OPENSPF) ALLOW(ALLOW(*BPGM *IPGM *BMOD *IMOD) ) CURLIB(*NOCHG) PRDLIB(*NOCHG)"
 						},
 						{
 							"type": "member",
@@ -402,7 +402,7 @@
 								"cmd"
 							],
 							"name": "Create Command (CRTCMD)",
-							"command": "?CRTCMD CMD(&BUILDLIB/&NAME) PGM(&BUILDLIB/&NAMEC) SRCSTMF('&FULLPATH') OPTION(*EVENTF)"
+							"command": "?CRTCMD CMD(&BUILDLIB/&NAME) PGM(&BUILDLIB/&NAME) SRCSTMF('&FULLPATH') OPTION(*EVENTF)"
 						},
 						{
 							"type": "streamfile",
@@ -410,7 +410,7 @@
 								"cmd"
 							],
 							"name": "Create Command (Allow Return Variables - CRTCMD)",
-							"command": "?CRTCMD CMD(&BUILDLIB/&NAME) PGM(&BUILDLIB/&NAMEC) SRCSTMF('&FULLPATH') ALLOW(*BPGM *IPGM *BMOD *IMOD *BREXX *IREXX) OPTION(*EVENTF)"
+							"command": "?CRTCMD CMD(&BUILDLIB/&NAME) PGM(&BUILDLIB/&NAME) SRCSTMF('&FULLPATH') ALLOW(*BPGM *IPGM *BMOD *IMOD *BREXX *IREXX) OPTION(*EVENTF)"
 						},
 						{
 							"type": "streamfile",

--- a/package.json
+++ b/package.json
@@ -399,6 +399,22 @@
 						{
 							"type": "streamfile",
 							"extensions": [
+								"cmd"
+							],
+							"name": "Create Command (CRTCMD)",
+							"command": "?CRTCMD CMD(&BUILDLIB/&NAME) PGM(&BUILDLIB/&NAMEC) SRCSTMF('&FULLPATH') OPTION(*EVENTF)"
+						},
+						{
+							"type": "streamfile",
+							"extensions": [
+								"cmd"
+							],
+							"name": "Create Command (Allow Return Variables - CRTCMD)",
+							"command": "?CRTCMD CMD(&BUILDLIB/&NAME) PGM(&BUILDLIB/&NAMEC) SRCSTMF('&FULLPATH') ALLOW(*BPGM *IPGM *BMOD *IMOD *BREXX *IREXX) OPTION(*EVENTF)"
+						},
+						{
+							"type": "streamfile",
+							"extensions": [
 								"GLOBAL"
 							],
 							"name": "Set CCSID to 1252",

--- a/package.json
+++ b/package.json
@@ -286,7 +286,7 @@
 								"CMD"
 							],
 							"name": "Create Command (CRTCMD)",
-							"command": "?CRTCMD CMD(&OPENLIB/&OPENMBR) PGM(&OPNLIB/&OPENMBRC) SRCFILE(&OPENLIB/&OPENSPF) ALLOW(*ALL) CURLIB(*NOCHG) PRDLIB(*NOCHG)"
+							"command": "?CRTCMD CMD(&OPENLIB/&OPENMBR) PGM(&OPENLIB/&OPENMBRC) SRCFILE(&OPENLIB/&OPENSPF) ALLOW(*ALL) CURLIB(*NOCHG) PRDLIB(*NOCHG)"
 						},
 						{
 							"type": "member",
@@ -294,7 +294,7 @@
 								"CMD"
 							],
 							"name": "Create Command (Allow Return Variables - CRTCMD)",
-							"command": "?CRTCMD CMD(&OPENLIB/&OPENMBR) PGM(&OPNLIB/&OPENMBRC) SRCFILE(&OPENLIB/&OPENSPF) ALLOW(ALLOW(*BPGM *IPGM *BMOD *IMOD) ) CURLIB(*NOCHG) PRDLIB(*NOCHG)"
+							"command": "?CRTCMD CMD(&OPENLIB/&OPENMBR) PGM(&OPENLIB/&OPENMBRC) SRCFILE(&OPENLIB/&OPENSPF) ALLOW(ALLOW(*BPGM *IPGM *BMOD *IMOD) ) CURLIB(*NOCHG) PRDLIB(*NOCHG)"
 						},
 						{
 							"type": "member",


### PR DESCRIPTION
### Changes

This change adds CRTCMD for streamfiles for the default actions.
It also fixes the default CRTCMD commands for members (misspelled variable).

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in the README
