### PR TITLE
New config to hide specific compile codes (#132)

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,15 @@
 								"type": "boolean",
 								"default": true,
 								"description": "Must be enabled to make the use of db2util and is enabled by default. If you find db2util isn't working for some reason, disable this. If this config is changed, you must reconnect to the system."
+							},
+							"hideCompileErrors": {
+								"type": "array",
+								"items": {
+									"type": "string",
+									"title": "IBM i error code"
+								},
+								"default": [],
+								"description": "List of codes that will be hidden in the result of an action (from the EVFEVENT file)"
 							}
 						}
 					}

--- a/src/api/CompileTools.js
+++ b/src/api/CompileTools.js
@@ -53,6 +53,9 @@ module.exports = class CompileTools {
   static async refreshDiagnostics(instance, evfeventInfo) {
     const content = instance.getContent();
 
+    /** @type {Configuration} */
+    const config = instance.getConfig();
+
     const tableData = await content.getTable(evfeventInfo.lib, `EVFEVENT`, evfeventInfo.object);
     const lines = tableData.map(row => row.EVFEVENT);
 
@@ -79,14 +82,16 @@ module.exports = class CompileTools {
             error.column = 0;
             error.toColumn = 100;
           }
-          
-          diagnostic = new vscode.Diagnostic(
-            new vscode.Range(error.linenum, error.column, error.linenum, error.toColumn),
-            `${error.code}: ${error.text} (${error.sev})`,
-            diagnosticSeverity[error.sev]
-          );
 
-          diagnostics.push(diagnostic);
+          if (!config.hideCompileErrors.includes(error.code)) {
+            diagnostic = new vscode.Diagnostic(
+              new vscode.Range(error.linenum, error.column, error.linenum, error.toColumn),
+              `${error.code}: ${error.text} (${error.sev})`,
+              diagnosticSeverity[error.sev]
+            );
+
+            diagnostics.push(diagnostic);
+          }
         }
 
         if (file.startsWith(`/`))

--- a/src/api/Configuration.js
+++ b/src/api/Configuration.js
@@ -37,6 +37,9 @@ module.exports = class Configuration {
 
     /** @type {boolean} */
     this.enableSQL = base.enableSQL;
+
+    /** @type {string[]} */
+    this.hideCompileErrors = base.hideCompileErrors || [];
   }
 
   /**

--- a/src/webviews/settings/index.js
+++ b/src/webviews/settings/index.js
@@ -39,6 +39,11 @@ module.exports = class SettingsUI {
         field.description = `The CCSID of source files on your system. You should only change this setting from <code>*FILE</code> if you have a source file that is 65535 - otherwise use <code>*FILE</code>. Note that this config is used to fetch all members. If you have any source files using 65535, you have bigger problems.`;
         ui.addField(field);
     
+        field = new Field(`input`, `hideCompileErrors`, `Errors to ignore`);
+        field.default = config.hideCompileErrors.join(`,`);
+        field.description = `A comma delimited list of errors to be hidden from the result of an Action in the EVFEVENT file. Useful for codes like <code>RNF5409</code>.`;
+        ui.addField(field);
+    
         field = new Field(`submit`, `save`, `Save settings`);
         ui.addField(field);
     
@@ -53,6 +58,9 @@ module.exports = class SettingsUI {
             switch (key) {
             case `sourceASP`:
               if (data[key].trim() === ``) data[key] = null;
+              break;
+            case `hideCompileErrors`:
+              data[key] = data[key].split(`,`).map(item => item.trim().toUpperCase()).filter(item => item !== ``);
               break;
             }
           }


### PR DESCRIPTION
### Changes

Adds brand new configuration to hide specific errors from the compile log.

### Checklist

* [X] have tested my change
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [X] **for feature PRs**: PR only includes one feature enhancement.
