### PR TITLE
Expose context

### DIFF
--- a/src/Instance.js
+++ b/src/Instance.js
@@ -5,6 +5,8 @@ const IBMi = require(`./api/IBMi`);
 const IBMiContent = require(`./api/IBMiContent`);
 const CompileTools = require(`./api/CompileTools`);
 
+const Disposable = require(`./api/Disposable`);
+
 /** @type {vscode.StatusBarItem} */
 let connectedBarItem;
 
@@ -157,57 +159,74 @@ module.exports = class Instance {
         //********* Library list view */
 
         context.subscriptions.push(
-          vscode.window.registerTreeDataProvider(
-            `libraryListView`,
-            new libraryListView(context)
+          Disposable(`libraryListView`, 
+            vscode.window.registerTreeDataProvider(
+              `libraryListView`,
+              new libraryListView(context)
+            )
           )
         );
 
         //********* Member Browser */
 
         context.subscriptions.push(
-          vscode.window.registerTreeDataProvider(
-            `memberBrowser`,
-            new memberBrowser(context)
+          Disposable(`memberBrowser`,
+            vscode.window.registerTreeDataProvider(
+              `memberBrowser`,
+              new memberBrowser(context)
+            )
           )
         );
 
 
         context.subscriptions.push(
-          //@ts-ignore
-          vscode.workspace.registerFileSystemProvider(`member`, qsysFs, { 
-            isCaseSensitive: false
-          })
+          Disposable(`member`,
+            //@ts-ignore
+            vscode.workspace.registerFileSystemProvider(`member`, qsysFs, { 
+              isCaseSensitive: false
+            })
+          )
         );
 
         //********* IFS Browser */
 
         context.subscriptions.push(
-          vscode.window.registerTreeDataProvider(
-            `ifsBrowser`,
-            new ifsBrowser(context)
-          ));
+          Disposable(`ifsBrowser`,
+            vscode.window.registerTreeDataProvider(
+              `ifsBrowser`,
+              new ifsBrowser(context)
+            )
+          )
+        );
   
         context.subscriptions.push(
-          //@ts-ignore
-          vscode.workspace.registerFileSystemProvider(`streamfile`, ifs, { 
-            isCaseSensitive: false
-          })
+          Disposable(`streamfile`,
+            //@ts-ignore
+            vscode.workspace.registerFileSystemProvider(`streamfile`, ifs, { 
+              isCaseSensitive: false
+            })
+          )
         );
 
         //********* Object Browser */
         
         context.subscriptions.push(
-          vscode.window.registerTreeDataProvider(
-            `objectBrowser`,
-            new objectBrowser(context)
-          ));
+          Disposable(`objectBrowser`,
+            vscode.window.registerTreeDataProvider(
+              `objectBrowser`,
+              new objectBrowser(context)
+            )
+          )
+        );
         
         context.subscriptions.push(
-          vscode.window.registerTreeDataProvider(
-            `databaseBrowser`,
-            new databaseBrowser(context)
-          ));
+          Disposable(`databaseBrowser`, 
+            vscode.window.registerTreeDataProvider(
+              `databaseBrowser`,
+              new databaseBrowser(context)
+            )
+          )
+        );
 
         //********* General editing */
   

--- a/src/api/Disposable.js
+++ b/src/api/Disposable.js
@@ -1,0 +1,12 @@
+const vscode = require(`vscode`);
+
+/**
+ * Attach an ID to a Disposable
+ * @param {string} id 
+ * @param {vscode.Disposable} disposable 
+ */
+module.exports = (id, disposable) => {
+  //@ts-ignore
+  disposable.id = id;
+  return disposable;
+}

--- a/src/extension.js
+++ b/src/extension.js
@@ -69,7 +69,7 @@ function activate(context) {
     })
   )
 
-  return {instance, CustomUI, Field};
+  return {instance, CustomUI, Field, baseContext: context};
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
### Changes

* Gives specific functionality IDs on their Dispose instances so other plugins can dispose of specific base functionality (in case they want to replace it)
* Expose the base context so other plugins can control them.

### Checklist

* [X] have tested my change
* [ ] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [X] **for feature PRs**: PR only includes one feature enhancement.
