### PR TITLE
Use current library over build library

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -109,7 +109,8 @@ Notice the special identifiers in the command begining with `&`. These identifie
 
 | Variable | Usage                              |
 |----------|------------------------------------|
-| `&BUILDLIB` | Values which comes from the connection settings |
+| `&CURLIB` | Values which comes from the connection settings |
+| `&BUILDLIB` | The same as `&CURLIB` |
 | `&USERNAME` | Username being used to connect to the current system |
 | `&HOME` | Home directory configured for the connection |
 
@@ -247,16 +248,20 @@ Source files to be included in the member browser.
 
 #### Library List
 
-An array for the library list. Highest item of the library list goes first. You are able to use `&BUILDLIB` in the library list, to make compiles dynamic.
+An array for the user library list. Highest item of the library list goes first.
 
 ```json
 "libraryList": [
-    "&BUILDLIB",
     "DATALIB",
     "QSYSINC"
 ]
 ```
 
+#### Current library
+
+The library which will be set as the current library during compilation.
+
+You can change the current library with the 'Change build library' command (F1 -> Change build library).
 #### Home Directory
 
 Home directory for user. This directory is also the root for the IFS browser.
@@ -264,11 +269,6 @@ Home directory for user. This directory is also the root for the IFS browser.
 #### Temporary library
 
 Temporary library. Is used to OUTPUT files. Cannot be QTEMP.
-
-#### Build library
-
-A library that can be defined/changed for IFS builds. You can also change the build library with the 'Change build library' command (F1 -> Change build library).
-
 #### Source ASP
 
 If source files are located in a specific ASP, specify here.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"onCommand:code-for-ibmi.compareWithSelected",
 		"onCommand:code-for-ibmi.showAdditionalSettings",
 		"onCommand:code-for-ibmi.showActionsMaintenance",
-		"onCommand:code-for-ibmi.changeBuildLibrary",
+		"onCommand:code-for-ibmi.changeCurrentLibrary",
 		"onView:libraryListView",
 		"onCommand:code-for-ibmi.refreshLibraryListView",
 		"onCommand:code-for-ibmi.addToLibraryList",
@@ -143,10 +143,10 @@
 								"default": "ILEDITOR",
 								"description": "Temporary library. Cannot be QTEMP."
 							},
-							"buildLibrary": {
+							"currentLibrary": {
 								"type": "string",
 								"default": "QTEMP",
-								"description": "Library used for &BUILDLIB when running actions from the IFS."
+								"description": "Library used as the current library and &CURLIB variable when running actions."
 							},
 							"sourceASP": {
 								"type": [
@@ -498,8 +498,8 @@
 				"category": "IBM i"
 			},
 			{
-				"command": "code-for-ibmi.changeBuildLibrary",
-				"title": "Change build library",
+				"command": "code-for-ibmi.changeCurrentLibrary",
+				"title": "Change current library",
 				"category": "IBM i",
 				"icon": "$(root-folder)"
 			},
@@ -710,7 +710,7 @@
 			"ibmi-explorer": [
 				{
 					"id": "libraryListView",
-					"name": "Library List"
+					"name": "User Library List"
 				},
 				{
 					"id": "memberBrowser",
@@ -735,7 +735,7 @@
 		"menus": {
 			"view/title": [
 				{
-					"command": "code-for-ibmi.changeBuildLibrary",
+					"command": "code-for-ibmi.changeCurrentLibrary",
 					"group": "navigation",
 					"when": "view == libraryListView"
 				},

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -271,18 +271,18 @@ module.exports = class Instance {
         );
 
         context.subscriptions.push(
-          vscode.commands.registerCommand(`code-for-ibmi.changeBuildLibrary`, async () => {
+          vscode.commands.registerCommand(`code-for-ibmi.changeCurrentLibrary`, async () => {
             const config = this.getConfig();
-            const buildLibrary = config.buildLibrary.toUpperCase();
+            const currentLibrary = config.currentLibrary.toUpperCase();
     
             const newLibrary = await vscode.window.showInputBox({
-              prompt: `Changing build library`,
-              value: buildLibrary
+              prompt: `Changing current library`,
+              value: currentLibrary
             });
     
             try {
-              if (newLibrary && newLibrary !== buildLibrary) {
-                await config.set(`buildLibrary`, newLibrary);
+              if (newLibrary && newLibrary !== currentLibrary) {
+                await config.set(`currentLibrary`, newLibrary);
               }
             } catch (e) {
               console.log(e);

--- a/src/api/CompileTools.js
+++ b/src/api/CompileTools.js
@@ -149,7 +149,8 @@ module.exports = class CompileTools {
         command = availableActions.find(action => action.name === chosenOptionName).command;
         environment = availableActions.find(action => action.name === chosenOptionName).environment || `ile`;
 
-        command = command.replace(new RegExp(`&BUILDLIB`, `g`), config.buildLibrary);
+        command = command.replace(new RegExp(`&BUILDLIB`, `g`), config.currentLibrary);
+        command = command.replace(new RegExp(`&CURLIB`, `g`), config.currentLibrary);
         command = command.replace(new RegExp(`&USERNAME`, `g`), connection.currentUser);
         command = command.replace(new RegExp(`&HOME`, `g`), config.homeDirectory);
 
@@ -202,7 +203,7 @@ module.exports = class CompileTools {
 
           evfeventInfo = {
             asp: undefined,
-            lib: config.buildLibrary,
+            lib: config.currentLibrary,
             object: name,
             ext
           };
@@ -259,13 +260,15 @@ module.exports = class CompileTools {
           libl = libl.map(library => {
             //We use this for special variables in the libl
             switch (library) {
-            case `&BUILDLIB`: return config.buildLibrary;
+            case `&BUILDLIB`: return config.currentLibrary;
+            case `&CURLIB`: return config.currentLibrary;
             default: return library;
             }
           });
 
-          outputChannel.append(`Library list: ` + libl.reverse().join(` `) + `\n`);
-          outputChannel.append(`Command: ` + command + `\n`);
+          outputChannel.append(`Current library: ` + config.currentLibrary + `\n`);
+          outputChannel.append(`   Library list: ` + libl.reverse().join(` `) + `\n`);
+          outputChannel.append(`        Command: ` + command + `\n`);
 
           try {
 
@@ -277,6 +280,7 @@ module.exports = class CompileTools {
             case `qsh`:
               commandResult = await connection.qshCommand([
                 `liblist -d ` + connection.defaultUserLibraries.join(` `),
+                `liblist -c ` + config.currentLibrary,
                 `liblist -a ` + libl.join(` `),
                 command,
               ], undefined, 1);

--- a/src/api/Configuration.js
+++ b/src/api/Configuration.js
@@ -27,7 +27,7 @@ module.exports = class Configuration {
     this.tempLibrary = base.tempLibrary || `ILEDITOR`;
 
     /** @type {string} */
-    this.buildLibrary = base.buildLibrary || `QTEMP`;
+    this.currentLibrary = base.currentLibrary || ``;
 
     /** @type {string|undefined} */
     this.sourceASP = base.sourceASP || undefined;

--- a/src/api/IBMi.js
+++ b/src/api/IBMi.js
@@ -53,7 +53,7 @@ module.exports = class IBMi {
 
       //Since the compiles are stateless, then we have to set the library list each time we use the `SYSTEM` command
       //We setup the defaultUserLibraries here so we can remove them later on so the user can setup their own library list
-      let currentLibrary = `QGPL`;
+      let currentLibrary;
       this.defaultUserLibraries = [];
       let libraryListString = await this.qshCommand(`liblist`);
       if (typeof libraryListString === `string` && libraryListString !== ``) {
@@ -76,6 +76,7 @@ module.exports = class IBMi {
         }
 
         //If this is the first time the config is made, then these arrays will be empty
+        if (this.config.currentLibrary.length === 0) await this.config.set(`currentLibrary`, currentLibrary);
         if (this.config.libraryList.length === 0) await this.config.set(`libraryList`, this.defaultUserLibraries);
         if (this.config.objectBrowserList.length === 0) await this.config.set(`objectBrowserList`, this.defaultUserLibraries);
         if (this.config.databaseBrowserList.length === 0) await this.config.set(`databaseBrowserList`, this.defaultUserLibraries);


### PR DESCRIPTION
### Changes

This fix will rename 'build library', to 'current library'. We're doing this for many reasons:

* It makes more sense to IBM i devs
* We can actually set the builds current library at compile time now

### Checklist

* [X] have tested my change
* [X] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [X] **for feature PRs**: PR only includes one feature enhancement.
