### PR TITLE
Basic IFS up- and download functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .vscode-test/
 *.vsix
 dist
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -83,3 +83,4 @@ More detailed documentation is available [here](https://halcyon-tech.github.io/c
 * [@SJLennon](https://github.com/SJLennon)
 * [@onewheelonly](https://github.com/onewheelonly)
 * [@chrjorgensen](https://github.com/chrjorgensen)
+* [@szsascha](https://github.com/szsascha)

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 		"onCommand:code-for-ibmi.createStreamfile",
 		"onCommand:code-for-ibmi.moveIFS",
 		"onCommand:code-for-ibmi.deleteIFS",
+		"onCommand:code-for-ibmi.downloadIFS",
 		"onView:objectBrowser",
 		"onCommand:code-for-ibmi.refreshObjectList",
 		"onCommand:code-for-ibmi.createSourceFile",
@@ -619,6 +620,11 @@
 				"category": "IBM i"
 			},
 			{
+				"command": "code-for-ibmi.downloadIFS",
+				"title": "Download",
+				"category": "IBM i"
+			},
+			{
 				"command": "code-for-ibmi.moveIFS",
 				"title": "Move object",
 				"category": "IBM i",
@@ -894,6 +900,11 @@
 					"command": "code-for-ibmi.createStreamfile",
 					"when": "view == ifsBrowser && viewItem == directory",
 					"group": "2_ifsStuff@1"
+				},
+				{
+					"command": "code-for-ibmi.downloadIFS",
+					"when": "view == ifsBrowser && viewItem == streamfile",
+					"group": "3_ifsTransfer@1"
 				},
 				{
 					"command": "code-for-ibmi.refreshObjectList",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"onCommand:code-for-ibmi.changeHomeDirectory",
 		"onCommand:code-for-ibmi.createDirectory",
 		"onCommand:code-for-ibmi.createStreamfile",
+		"onCommand:code-for-ibmi.uploadStreamfile",
 		"onCommand:code-for-ibmi.moveIFS",
 		"onCommand:code-for-ibmi.deleteIFS",
 		"onCommand:code-for-ibmi.downloadIFS",
@@ -643,6 +644,12 @@
 				"icon": "$(new-file)"
 			},
 			{
+				"command": "code-for-ibmi.uploadStreamfile",
+				"title": "Upload",
+				"category": "IBM i",
+				"icon": "$(cloud-upload)"
+			},
+			{
 				"command": "code-for-ibmi.refreshObjectList",
 				"title": "Refresh Object List",
 				"category": "IBM i",
@@ -776,6 +783,11 @@
 					"when": "view == ifsBrowser"
 				},
 				{
+					"command": "code-for-ibmi.uploadStreamfile",
+					"group": "navigation",
+					"when": "view == ifsBrowser"
+				},
+				{
 					"command": "code-for-ibmi.changeHomeDirectory",
 					"group": "navigation",
 					"when": "view == ifsBrowser"
@@ -905,6 +917,11 @@
 					"command": "code-for-ibmi.downloadIFS",
 					"when": "view == ifsBrowser && viewItem == streamfile",
 					"group": "3_ifsTransfer@1"
+				},
+				{
+					"command": "code-for-ibmi.uploadStreamfile",
+					"when": "view == ifsBrowser && viewItem == directory",
+					"group": "3_ifsTransfer@2"
 				},
 				{
 					"command": "code-for-ibmi.refreshObjectList",

--- a/src/api/IBMiContent.js
+++ b/src/api/IBMiContent.js
@@ -20,13 +20,14 @@ module.exports = class IBMiContent {
 
   /**
    * @param {string} remotePath 
+   * @param {string} localPath 
    */
-  async downloadStreamfile(remotePath) {
+  async downloadStreamfile(remotePath, localPath = null) {
     const client = this.ibmi.client;
 
-    let tmpobj = await tmpFile();
-    await client.getFile(tmpobj, remotePath);
-    return readFileAsync(tmpobj, `utf8`);
+    if (localPath == null) localPath = await tmpFile();
+    await client.getFile(localPath, remotePath);
+    return readFileAsync(localPath, `utf8`);
   }
 
   async writeStreamfile(remotePath, content) {

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -243,7 +243,7 @@ module.exports = class ifsBrowserProvider {
 
           } else {
             //Get filename from path on server
-            const filename = node.path.replace(/^.*[\\\/]/, '');
+            const filename = node.path.replace(/^.*[\\\/]/, ``);
 
             const remoteFilepath = path.join(os.homedir(), filename);
 

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -1,6 +1,8 @@
 
 const { throws } = require(`assert`);
 const vscode = require(`vscode`);
+const os = require(`os`);
+const path = require(`path`);
 
 let instance = require(`../Instance`);
 const Configuration = require(`../api/Configuration`);
@@ -173,6 +175,32 @@ module.exports = class ifsBrowserProvider {
         } else {
           //Running from command
           console.log(this);
+        }
+      }),
+
+      vscode.commands.registerCommand(`code-for-ibmi.downloadIFS`, async (node) => {
+
+        if (node) {
+          const isStillOpen = vscode.workspace.textDocuments.find(document => document.uri.path === node.path);
+
+          if (isStillOpen) {
+            //Be sure it's correctly saved
+            vscode.window.showInformationMessage(`Cannot download streamfile while it is open.`);
+
+          } else {
+            //Get filename from path on server
+            const filename = node.path.replace(/^.*[\\\/]/, '');
+
+            const remoteFilepath = path.join(os.homedir(), filename);
+
+            let localFilepath = await vscode.window.showSaveDialog({defaultUri: vscode.Uri.file(remoteFilepath)});
+            
+            const content = instance.getContent();
+            content.downloadStreamfile(node.path, localFilepath.path);
+            vscode.window.showInformationMessage(`Download of file ${node.path} to ${localFilepath.path} started!`);
+          }
+        } else {
+          //Running from command.
         }
       })
     )

--- a/src/views/ifsBrowser.js
+++ b/src/views/ifsBrowser.js
@@ -140,6 +140,7 @@ module.exports = class ifsBrowserProvider {
             prompt: `Name of new streamfile`,
             value: destPathSuggestion
           });
+          if(!destinationPath) return;
 
           try {
             vscode.window.showInformationMessage(`Creating and uploading streamfile ${destinationPath}.`);


### PR DESCRIPTION
### Changes

Basic IFS upload and download functionality implemented as requested in #45.
Very simple but a start.

You're able to download files from the IFS browser with right-click and "Download".

There are two way's to upload files:
1. Use the upload icon in the IFS browser header
2. Use right-click and "Upload" on a directory

During development, I made a note of the following points to consider for the future:
1. Does it work correctly on Windows? I've tested it on macOS. Maybe there are some path specialties on another OS?
2. I've not tested the up- and download of files with a large size. The IBMiContent class is very basic at the moment and currently not supporting progress tracking.
3. Up- and downloading of directories didn't work yet
4. Only utf8 files are supported at the moment because of the configurations in IBMiContent. Maybe we've to create a new module or we've to extend the IBMiContent class.

### Checklist

* [x] have tested my change
* [x] updated relevant documentation
* [x] Remove any/all `console.log`s I added
* [x] eslint is not complaining
* [x] have added myself to the contributors' list in the README
* [x] **for feature PRs**: PR only includes one feature enhancement.
