### PR TITLE
Create output channel for all remote commands

### DIFF
--- a/src/Instance.js
+++ b/src/Instance.js
@@ -70,6 +70,9 @@ module.exports = class Instance {
     }
 
     if (doDisconnect) {
+      //Dispose of any vscode related internals.
+      instance.connection.subscriptions.forEach(subscription => subscription.dispose());
+
       if (instance.connection) {
         instance.connection.client.dispose();
         instance.connection = undefined;

--- a/src/api/IBMi.js
+++ b/src/api/IBMi.js
@@ -1,4 +1,6 @@
 
+const vscode = require(`vscode`);
+
 const node_ssh = require(`node-ssh`);
 const Configuration = require(`./Configuration`);
 
@@ -11,6 +13,12 @@ module.exports = class IBMi {
     
     this.tempRemoteFiles = {};
     this.defaultUserLibraries = [];
+
+    /** @type {vscode.OutputChannel} */
+    this.outputChannel = vscode.window.createOutputChannel(`Code for IBM i`);
+
+    /** @type {vscode.Disposable[]} List of vscode disposables */
+    this.subscriptions = [this.outputChannel];
 
     /**
      * Used to store ASP numbers and their names
@@ -217,9 +225,14 @@ module.exports = class IBMi {
   async paseCommand(command, directory = this.config.homeDirectory, returnType = 0) {
     command = command.replace(/\$/g, `\\$`);
 
-    let result = await this.client.execCommand(command, {
+    this.outputChannel.append(`${directory}: ${command}\n`);
+
+    const result = await this.client.execCommand(command, {
       cwd: directory,
     });
+
+    this.outputChannel.append(JSON.stringify(result, null, 4) + `\n`);
+    this.outputChannel.append(`\n`);
 
     if (returnType === 0) {
       if (result.code === 0 || result.code === null) return Promise.resolve(result.stdout);


### PR DESCRIPTION
### Changes

Create an output channel for all remote commands. This will be used to mostly help users debug their issues. It will allow them to share with us the commands and output they get for us to debug the issues.

### Checklist

* [X] have tested my change
* [ ] updated relevant documentation
* [X] Remove any/all `console.log`s I added
* [X] eslint is not complaining
* [ ] have added myself to the contributors' list in the README
* [X] **for feature PRs**: PR only includes one feature enhancement.
